### PR TITLE
Move cropImageMainHelper.h include to header

### DIFF
--- a/src/cropimage/cropimage.cxx
+++ b/src/cropimage/cropimage.cxx
@@ -27,7 +27,6 @@
 #include "itkCommandLineArgumentParser.h"
 #include "ITKToolsHelpers.h"
 #include "cropimage.h"
-#include "cropimageMainHelper.h"
 
 
 /**

--- a/src/cropimage/cropimage.h
+++ b/src/cropimage/cropimage.h
@@ -27,6 +27,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 
+#include "cropimageMainHelper.h"
 
 /** \class ITKToolsCropImageBase
  *


### PR DESCRIPTION
The file must be include in the header before the
the call to GetUpperBoundary and GetLowerBoundary.

Otherwise compilation on mac os x 10.9.2 fails.
