### PR TITLE
COMP: Upgrade to ITK5

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required( VERSION 2.6 )
+# Require at least ITK_OLDEST_VALIDATED_POLICIES_VERSION from
+# https://github.com/InsightSoftwareConsortium/ITK/blob/v5.0.0/CMakeLists.txt#L13 
+cmake_minimum_required( VERSION 3.10.2 )
 
 # This project is intended to be built outside the Insight source tree
 project( ITKTOOLS )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ project( ITKTOOLS )
 
 #---------------------------------------------------------------------
 # Find ITK.
-FIND_PACKAGE( ITK 4 REQUIRED )
+FIND_PACKAGE( ITK 5 REQUIRED )
 include( ${ITK_USE_FILE} )
 
 # ITKTools depends on some ITK modules. Check for them:

--- a/src/averagevectormagnitude/averagevectormagnitude.cxx
+++ b/src/averagevectormagnitude/averagevectormagnitude.cxx
@@ -83,7 +83,7 @@ int main( int argc, char** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/averagevectormagnitude/averagevectormagnitude.cxx
+++ b/src/averagevectormagnitude/averagevectormagnitude.cxx
@@ -82,7 +82,7 @@ int main( int argc, char** argv )
   parser->GetCommandLineArgument( "-out", outputFileName );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/averagevectormagnitude/averagevectormagnitude.cxx
+++ b/src/averagevectormagnitude/averagevectormagnitude.cxx
@@ -83,7 +83,7 @@ int main( int argc, char** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/averagevectormagnitude/averagevectormagnitude.cxx
+++ b/src/averagevectormagnitude/averagevectormagnitude.cxx
@@ -82,7 +82,7 @@ int main( int argc, char** argv )
   parser->GetCommandLineArgument( "-out", outputFileName );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/averagevectormagnitude/averagevectormagnitude.h
+++ b/src/averagevectormagnitude/averagevectormagnitude.h
@@ -70,7 +70,7 @@ public:
   ~ITKToolsAverageVectorMagnitude(){};
 
   static Self * New( unsigned int imageDimension,
-    itk::ImageIOBase::IOComponentType componentType,
+    itk::ImageIOBase::IOComponentEnum componentType,
     unsigned int vectorDimension )
   {
     if( VDimension == imageDimension

--- a/src/binaryimageoperator/BinaryImageOperatorHelper.h
+++ b/src/binaryimageoperator/BinaryImageOperatorHelper.h
@@ -151,7 +151,7 @@ public:
     std::string binaryOperatorName = this->m_Ops;
 
     /** Set up the binaryFilter. */
-    typename BaseFilterType::Pointer binaryFilter = 0;
+    typename BaseFilterType::Pointer binaryFilter = nullptr;
     if( binaryOperatorName == "ADDITION" )
     {
       typename ADDITIONFilterType::Pointer tempBinaryFilter = ADDITIONFilterType::New();

--- a/src/binaryimageoperator/BinaryImageOperatorMainHelper.h
+++ b/src/binaryimageoperator/BinaryImageOperatorMainHelper.h
@@ -131,11 +131,11 @@ int DetermineComponentTypes(
   bool outIsInteger = itktools::ComponentTypeIsInteger( componentTypeOut );
   if( outIsInteger )
   {
-    componentType1 = componentType2 = itk::ImageIOBase::LONG;
+    componentType1 = componentType2 = itk::IOComponentEnum::LONG;
   }
   else
   {
-    componentType1 = componentType2 = itk::ImageIOBase::DOUBLE;
+    componentType1 = componentType2 = itk::IOComponentEnum::DOUBLE;
   }
 
   /** Return a value. */

--- a/src/binaryimageoperator/BinaryImageOperatorMainHelper.h
+++ b/src/binaryimageoperator/BinaryImageOperatorMainHelper.h
@@ -32,9 +32,9 @@
 
 int DetermineComponentTypes(
   const std::vector<std::string> & inputFileNames,
-  itk::ImageIOBase::IOComponentType & componentType1,
-  itk::ImageIOBase::IOComponentType & componentType2,
-  itk::ImageIOBase::IOComponentType & componentTypeOut )
+  itk::ImageIOBase::IOComponentEnum & componentType1,
+  itk::ImageIOBase::IOComponentEnum & componentType2,
+  itk::ImageIOBase::IOComponentEnum & componentTypeOut )
 {
   // Note: a bit of an ugly combination between itktools
   // and itk::ImageIOBase functionality.

--- a/src/binaryimageoperator/binaryimageoperator.cxx
+++ b/src/binaryimageoperator/binaryimageoperator.cxx
@@ -140,7 +140,7 @@ int main( int argc, char **argv )
     }
     if( !itktools::ComponentTypeIsInteger( componentTypeOut ) )
     {
-      componentType1 = componentType2 = itk::ImageIOBase::DOUBLE;
+      componentType1 = componentType2 = itk::IOComponentEnum::DOUBLE;
     }
   }
 

--- a/src/binaryimageoperator/binaryimageoperator.cxx
+++ b/src/binaryimageoperator/binaryimageoperator.cxx
@@ -154,7 +154,7 @@ int main( int argc, char **argv )
   if( !retCOA ) return EXIT_FAILURE;
 
   /** Class that does the work. */
-  ITKToolsBinaryImageOperatorBase * filter = NULL;
+  ITKToolsBinaryImageOperatorBase * filter = nullptr;
 
   unsigned int dim = 0;
   itktools::GetImageDimension( inputFileNames[1], dim );

--- a/src/binaryimageoperator/binaryimageoperator.cxx
+++ b/src/binaryimageoperator/binaryimageoperator.cxx
@@ -124,9 +124,9 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOComponentType componentType1;
-  itk::ImageIOBase::IOComponentType componentType2;
-  itk::ImageIOBase::IOComponentType componentTypeOut;
+  itk::ImageIOBase::IOComponentEnum componentType1;
+  itk::ImageIOBase::IOComponentEnum componentType2;
+  itk::ImageIOBase::IOComponentEnum componentTypeOut;
   DetermineComponentTypes( inputFileNames, componentType1, componentType2, componentTypeOut );
 
   /** Let the user override the output component type. */
@@ -160,9 +160,9 @@ int main( int argc, char **argv )
   itktools::GetImageDimension( inputFileNames[1], dim );
 
   /** Short aliases. */
-  itk::ImageIOBase::IOComponentType inCType1 = componentType1;
-  itk::ImageIOBase::IOComponentType inCType2 = componentType2;
-  itk::ImageIOBase::IOComponentType outCType = componentTypeOut;
+  itk::ImageIOBase::IOComponentEnum inCType1 = componentType1;
+  itk::ImageIOBase::IOComponentEnum inCType2 = componentType2;
+  itk::ImageIOBase::IOComponentEnum outCType = componentTypeOut;
 
   try
   {

--- a/src/binaryimageoperator/itkBinaryFunctors.h
+++ b/src/binaryimageoperator/itkBinaryFunctors.h
@@ -223,7 +223,7 @@ public:
   {
     const double A = static_cast<double>( a );
     const double B = static_cast<double>( b );
-    const double result1 = vnl_math_max( A, B );
+    const double result1 = std::max( A, B );
     const double result2 = ( result1 < NumericTraits<TOutput>::max() )
       ? result1 : NumericTraits<TOutput>::max();
     const double result3 = ( result2 > NumericTraits<TOutput>::NonpositiveMin() )

--- a/src/binaryimageoperator/itkBinaryFunctors.h
+++ b/src/binaryimageoperator/itkBinaryFunctors.h
@@ -253,7 +253,7 @@ public:
   {
     const double A = static_cast<double>( a );
     const double B = static_cast<double>( b );
-    const double result1 = vnl_math_min( A, B );
+    const double result1 = std::min( A, B );
     const double result2 = ( result1 < NumericTraits<TOutput>::max() )
       ? result1 : NumericTraits<TOutput>::max();
     const double result3 = ( result2 > NumericTraits<TOutput>::NonpositiveMin() )

--- a/src/binaryimageoperator/itkBinaryFunctors.h
+++ b/src/binaryimageoperator/itkBinaryFunctors.h
@@ -193,7 +193,7 @@ public:
   {
     const double A = static_cast<double>( a );
     const double B = static_cast<double>( b );
-    const double result1 = vcl_pow( A, B );
+    const double result1 = std::pow( A, B );
     const double result2 = ( result1 < NumericTraits<TOutput>::max() )
       ? result1 : NumericTraits<TOutput>::max();
     const double result3 = ( result2 > NumericTraits<TOutput>::NonpositiveMin() )

--- a/src/binaryimageoperator/itkBinaryFunctors.h
+++ b/src/binaryimageoperator/itkBinaryFunctors.h
@@ -412,7 +412,7 @@ public:
   {
     const double A = static_cast<double>( a );
     const double B = static_cast<double>( b );
-    return static_cast<TOutput>( vcl_log( A ) / vcl_log( B ) );
+    return static_cast<TOutput>( std::log( A ) / std::log( B ) );
   }
 }; // end class LOG
 

--- a/src/binaryimageoperator/itkBinaryFunctors.h
+++ b/src/binaryimageoperator/itkBinaryFunctors.h
@@ -333,7 +333,7 @@ public:
   {
     const double A = static_cast<double>( a );
     const double B = static_cast<double>( b );
-    return static_cast<TOutput>( vcl_sqrt( A * A + B * B ) );
+    return static_cast<TOutput>( std::sqrt( A * A + B * B ) );
   }
 }; // end class BINARYMAGNITUDE
 

--- a/src/binarythinning/binarythinning.cxx
+++ b/src/binarythinning/binarythinning.cxx
@@ -82,7 +82,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/binarythinning/binarythinning.cxx
+++ b/src/binarythinning/binarythinning.cxx
@@ -82,7 +82,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/binarythinning/binarythinning.cxx
+++ b/src/binarythinning/binarythinning.cxx
@@ -81,7 +81,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/binarythinning/binarythinning.cxx
+++ b/src/binarythinning/binarythinning.cxx
@@ -81,7 +81,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/braindistance/braindistance.cxx
+++ b/src/braindistance/braindistance.cxx
@@ -125,7 +125,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/braindistance/braindistance.cxx
+++ b/src/braindistance/braindistance.cxx
@@ -450,7 +450,7 @@ void ComputeBrainDistance(
   {
     if( statFilterLabelsSpecial->HasLabel( i ) )
     {
-      sigma_itot[ i ] = vcl_sqrt( statFilterLabelsSpecial->GetMean( i ) );
+      sigma_itot[ i ] = std::sqrt( statFilterLabelsSpecial->GetMean( i ) );
     }
     else
     {

--- a/src/braindistance/braindistance.cxx
+++ b/src/braindistance/braindistance.cxx
@@ -125,7 +125,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/braindistance/braindistance.cxx
+++ b/src/braindistance/braindistance.cxx
@@ -126,7 +126,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   std::vector<unsigned int> imageSize;

--- a/src/braindistance/braindistance.cxx
+++ b/src/braindistance/braindistance.cxx
@@ -126,7 +126,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   std::vector<unsigned int> imageSize;

--- a/src/braindistance/braindistance.cxx
+++ b/src/braindistance/braindistance.cxx
@@ -290,12 +290,12 @@ void ComputeBrainDistance(
 
   /** Instantiate main variables */
   InputReaderType::Pointer inputReader = InputReaderType::New();
-  InputImageType::Pointer inputImage = 0;
+  InputImageType::Pointer inputImage = nullptr;
   MaskReaderType::Pointer maskReader = MaskReaderType::New();
   MaskCropFilterType::Pointer maskCropFilter = MaskCropFilterType::New();
-  MaskImageType::Pointer labelMask = 0;
-  MaskImageType::Pointer brainMask = 0;
-  InternalImageType::Pointer jacobian = 0;
+  MaskImageType::Pointer labelMask = nullptr;
+  MaskImageType::Pointer brainMask = nullptr;
+  InternalImageType::Pointer jacobian = nullptr;
   JacobianCropFilterType::Pointer jacobianCropFilter = JacobianCropFilterType::New();
   ThresholderType::Pointer thresholder = ThresholderType::New();
   StatFilterType::Pointer statFilterBrainMask = StatFilterType::New();
@@ -307,7 +307,7 @@ void ComputeBrainDistance(
   LogFilterType::Pointer logFilter = LogFilterType::New();
 
   /** method 0 or 1 */
-  JacobianFilterType::Pointer jacobianFilter = 0;
+  JacobianFilterType::Pointer jacobianFilter = nullptr;
   if( method==0 || method ==2 )
   {
     jacobianFilter = JacobianFilterType::New();

--- a/src/braindistance/itkDeformationFieldBendingEnergyFilter.txx
+++ b/src/braindistance/itkDeformationFieldBendingEnergyFilter.txx
@@ -45,7 +45,7 @@ DeformationFieldBendingEnergyFilter< TInputImage, TRealType, TOutputImage >
     const RealVectorType q = it.GetPrevious(i);
     const RealVectorType pqc = p + q - c2;
     bending += pqc.GetSquaredNorm() *
-      vcl_pow( this->m_HalfDerivativeWeights[ i ], static_cast<int>(4) );
+      std::pow( this->m_HalfDerivativeWeights[ i ], static_cast<int>(4) );
   }
   /** off-diagonal: */
   for( unsigned int i = 0; i < ImageDimension; ++i )

--- a/src/braindistance/itkDeformationFieldBendingEnergyFilter.txx
+++ b/src/braindistance/itkDeformationFieldBendingEnergyFilter.txx
@@ -57,7 +57,7 @@ DeformationFieldBendingEnergyFilter< TInputImage, TRealType, TOutputImage >
       const RealVectorType r = it.GetPixel( it.GetCenterNeighborhoodIndex() + it.GetStride(i) - it.GetStride(j) );
       const RealVectorType s = it.GetPixel( it.GetCenterNeighborhoodIndex() - it.GetStride(i) + it.GetStride(j) );
       const RealVectorType pqrs = p + q - r - s;
-      bending += 2.0 * pqrs.GetSquaredNorm() * vnl_math_sqr(
+      bending += 2.0 * pqrs.GetSquaredNorm() * vnl_math::sqr(
           this->m_HalfDerivativeWeights[ i ] * this->m_HalfDerivativeWeights[j] );
     }
   }

--- a/src/castconvert/castconvert.cxx
+++ b/src/castconvert/castconvert.cxx
@@ -104,19 +104,19 @@ std::string GetHelpString( void )
 /** Break the program into smaller compilation units. */
 extern void ITKToolsCastConvert2D(
   unsigned int dim,
-  itk::ImageIOBase::IOComponentType outputComponentType,
+  itk::ImageIOBase::IOComponentEnum outputComponentType,
   ITKToolsCastConvertBase * & castConvert );
 extern void ITKToolsCastConvert3D(
   unsigned int dim,
-  itk::ImageIOBase::IOComponentType outputComponentType,
+  itk::ImageIOBase::IOComponentEnum outputComponentType,
   ITKToolsCastConvertBase * & castConvert );
 extern void ITKToolsCastConvert4D(
   unsigned int dim,
-  itk::ImageIOBase::IOComponentType outputComponentType,
+  itk::ImageIOBase::IOComponentEnum outputComponentType,
   ITKToolsCastConvertBase * & castConvert );
 extern void ITKToolsCastConvertDICOM3D(
   unsigned int dim,
-  itk::ImageIOBase::IOComponentType outputComponentType,
+  itk::ImageIOBase::IOComponentEnum outputComponentType,
   ITKToolsCastConvertBase * & castConvert );
 
 //-------------------------------------------------------------------------------------
@@ -224,7 +224,7 @@ int main( int argc, char **argv )
 
   /** Get dimension and component type. */
   itktools::GetImageDimension( inputFileName, dim );
-  itk::ImageIOBase::IOComponentType componentType
+  itk::ImageIOBase::IOComponentEnum componentType
     = itktools::GetImageComponentType( inputFileName );
   if( retopct )
   {

--- a/src/castconvert/castconvert.cxx
+++ b/src/castconvert/castconvert.cxx
@@ -232,7 +232,7 @@ int main( int argc, char **argv )
   }
 
   /** Class that does the work. */
-  ITKToolsCastConvertBase * castConvert = NULL;
+  ITKToolsCastConvertBase * castConvert = nullptr;
 
   try
   {

--- a/src/castconvert/castconvert.h
+++ b/src/castconvert/castconvert.h
@@ -38,11 +38,9 @@
 
 /** One of these is used to cast the image. */
 #include "itkCastImageFilter.h"
-#include "itkVectorCastImageFilter.h"
 #include "itkVectorIndexSelectionCastImageFilter.h"
 #include "itkComposeImageFilter.h"
 //#include "itkShiftScaleImageFilter.h"
-#include "itkVectorCastImageFilter.h"
 
 
 /** \class ITKToolsCastConvertBase

--- a/src/castconvert/castconvert2D.cxx
+++ b/src/castconvert/castconvert2D.cxx
@@ -20,7 +20,7 @@
 
 void ITKToolsCastConvert2D(
   unsigned int dim,
-  itk::ImageIOBase::IOComponentType componentType,
+  itk::ImageIOBase::IOComponentEnum componentType,
   ITKToolsCastConvertBase * & filter )
 {
   if( !filter ) filter = ITKToolsCastConvert< 2, short >::New( dim, componentType );

--- a/src/castconvert/castconvert3D.cxx
+++ b/src/castconvert/castconvert3D.cxx
@@ -20,7 +20,7 @@
 
 void ITKToolsCastConvert3D(
   unsigned int dim,
-  itk::ImageIOBase::IOComponentType componentType,
+  itk::ImageIOBase::IOComponentEnum componentType,
   ITKToolsCastConvertBase * & filter )
 {
   if( !filter ) filter = ITKToolsCastConvert< 3, short >::New( dim, componentType );

--- a/src/castconvert/castconvert4D.cxx
+++ b/src/castconvert/castconvert4D.cxx
@@ -20,7 +20,7 @@
 
 void ITKToolsCastConvert4D(
   unsigned int dim,
-  itk::ImageIOBase::IOComponentType componentType,
+  itk::ImageIOBase::IOComponentEnum componentType,
   ITKToolsCastConvertBase * & filter )
 {
   if( !filter ) filter = ITKToolsCastConvert< 4, short >::New( dim, componentType );

--- a/src/castconvert/castconvertDICOM.cxx
+++ b/src/castconvert/castconvertDICOM.cxx
@@ -20,7 +20,7 @@
 
 void ITKToolsCastConvertDICOM3D(
   unsigned int dim,
-  itk::ImageIOBase::IOComponentType componentType,
+  itk::ImageIOBase::IOComponentEnum componentType,
   ITKToolsCastConvertBase * & filter )
 {
   if( !filter ) filter = ITKToolsCastConvertDICOM< 3, short >::New( dim, componentType );

--- a/src/changeimageinformation/changeimageinformation.cxx
+++ b/src/changeimageinformation/changeimageinformation.cxx
@@ -88,7 +88,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/changeimageinformation/changeimageinformation.cxx
+++ b/src/changeimageinformation/changeimageinformation.cxx
@@ -87,7 +87,7 @@ int main( int argc, char ** argv )
   parser->GetCommandLineArgument( "-ref", referenceFileName );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/changeimageinformation/changeimageinformation.cxx
+++ b/src/changeimageinformation/changeimageinformation.cxx
@@ -100,7 +100,7 @@ int main( int argc, char ** argv )
   if( !retNOCCheck ) return EXIT_FAILURE;
 
   /** Class that does the work. */
-  ITKToolsChangeImageInformationBase * filter = NULL;
+  ITKToolsChangeImageInformationBase * filter = nullptr;
 
   try
   {

--- a/src/changeimageinformation/changeimageinformation.cxx
+++ b/src/changeimageinformation/changeimageinformation.cxx
@@ -88,7 +88,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/changeimageinformation/changeimageinformation.cxx
+++ b/src/changeimageinformation/changeimageinformation.cxx
@@ -87,7 +87,7 @@ int main( int argc, char ** argv )
   parser->GetCommandLineArgument( "-ref", referenceFileName );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/closestversor3Dtransform/closestversor3Dtransform.h
+++ b/src/closestversor3Dtransform/closestversor3Dtransform.h
@@ -161,9 +161,9 @@ void ConvertVersorToEuler(
   double q3 = parVersor[ 2 ];
 
   /** Computer Euler angles. */
-  parEuler[ 0 ] = vcl_atan2( 2.0 * ( q0 * q1 + q2 * q3 ), 1.0 - 2.0 * ( q1 * q1 + q2 * q2 ) );
+  parEuler[ 0 ] = std::atan2( 2.0 * ( q0 * q1 + q2 * q3 ), 1.0 - 2.0 * ( q1 * q1 + q2 * q2 ) );
   parEuler[ 1 ] = std::asin( 2.0 * ( q0 * q2 - q3 * q1 ) );
-  parEuler[ 2 ] = vcl_atan2( 2.0 * ( q0 * q3 + q1 * q2 ), 1.0 - 2.0 * ( q2 * q2 + q3 * q3 ) );
+  parEuler[ 2 ] = std::atan2( 2.0 * ( q0 * q3 + q1 * q2 ), 1.0 - 2.0 * ( q2 * q2 + q3 * q3 ) );
   parEuler[ 3 ] = parVersor[ 3 ];
   parEuler[ 4 ] = parVersor[ 4 ];
   parEuler[ 5 ] = parVersor[ 5 ];

--- a/src/closestversor3Dtransform/closestversor3Dtransform.h
+++ b/src/closestversor3Dtransform/closestversor3Dtransform.h
@@ -154,7 +154,7 @@ void ConvertVersorToEuler(
   parEuler.resize( nop, 0.0 );
 
   /** Easy notation. */
-  double q0 = vcl_sqrt( 1.0 - parVersor[ 0 ] * parVersor[ 0 ]
+  double q0 = std::sqrt( 1.0 - parVersor[ 0 ] * parVersor[ 0 ]
     - parVersor[ 1 ] * parVersor[ 1 ] - parVersor[ 2 ] * parVersor[ 2 ] );
   double q1 = parVersor[ 0 ];
   double q2 = parVersor[ 1 ];

--- a/src/closestversor3Dtransform/closestversor3Dtransform.h
+++ b/src/closestversor3Dtransform/closestversor3Dtransform.h
@@ -162,7 +162,7 @@ void ConvertVersorToEuler(
 
   /** Computer Euler angles. */
   parEuler[ 0 ] = vcl_atan2( 2.0 * ( q0 * q1 + q2 * q3 ), 1.0 - 2.0 * ( q1 * q1 + q2 * q2 ) );
-  parEuler[ 1 ] = vcl_asin( 2.0 * ( q0 * q2 - q3 * q1 ) );
+  parEuler[ 1 ] = std::asin( 2.0 * ( q0 * q2 - q3 * q1 ) );
   parEuler[ 2 ] = vcl_atan2( 2.0 * ( q0 * q3 + q1 * q2 ), 1.0 - 2.0 * ( q2 * q2 + q3 * q3 ) );
   parEuler[ 3 ] = parVersor[ 3 ];
   parEuler[ 4 ] = parVersor[ 4 ];

--- a/src/combinesegmentations/combinesegmentations.cxx
+++ b/src/combinesegmentations/combinesegmentations.cxx
@@ -258,7 +258,7 @@ int main( int argc, char **argv )
     maximumNumberOfThreads );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/combinesegmentations/combinesegmentations.cxx
+++ b/src/combinesegmentations/combinesegmentations.cxx
@@ -258,7 +258,7 @@ int main( int argc, char **argv )
     maximumNumberOfThreads );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/combinesegmentations/combinesegmentations.cxx
+++ b/src/combinesegmentations/combinesegmentations.cxx
@@ -259,7 +259,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/combinesegmentations/combinesegmentations.cxx
+++ b/src/combinesegmentations/combinesegmentations.cxx
@@ -259,7 +259,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/combinesegmentations/combinesegmentations.cxx
+++ b/src/combinesegmentations/combinesegmentations.cxx
@@ -251,10 +251,10 @@ int main( int argc, char **argv )
 
   /** Threads. */
   unsigned int maximumNumberOfThreads
-    = itk::MultiThreader::GetGlobalDefaultNumberOfThreads();
+    = itk::MultiThreaderBase::GetGlobalDefaultNumberOfThreads();
   parser->GetCommandLineArgument(
     "-threads", maximumNumberOfThreads );
-  itk::MultiThreader::SetGlobalMaximumNumberOfThreads(
+  itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads(
     maximumNumberOfThreads );
 
   /** Determine image properties. */

--- a/src/combinesegmentations/combinesegmentations.h
+++ b/src/combinesegmentations/combinesegmentations.h
@@ -24,7 +24,6 @@
 #include <vector>
 
 #include "itkImage.h"
-#include "itkExceptionObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkSTAPLEImageFilter.h"

--- a/src/combinesegmentations/combinesegmentations.h
+++ b/src/combinesegmentations/combinesegmentations.h
@@ -186,12 +186,12 @@ public:
 
     /** Declare some variables */
     unsigned int numberOfObservers = 0;
-    SegmentationCombinerType::Pointer segmentationCombiner = 0;
+    SegmentationCombinerType::Pointer segmentationCombiner = nullptr;
     LabelImageArrayType labelImageArray;
     ProbImageArrayType priorProbImageArray;
     ProbImageArrayType softSegmentationArray;
-    LabelImagePointer hardSegmentation = 0;
-    ConfusionMatrixImagePointer confusionMatrixImage = 0;
+    LabelImagePointer hardSegmentation = nullptr;
+    ConfusionMatrixImagePointer confusionMatrixImage = nullptr;
 
     /** Initialize some variables */
     numberOfObservers = this->m_InputSegmentationFileNames.size();

--- a/src/combinesegmentations/combinesegmentations.h
+++ b/src/combinesegmentations/combinesegmentations.h
@@ -37,7 +37,7 @@
 #include "itkBinaryDilateImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkChangeLabelImageFilter.h"
-#include "itkMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 
 
 /** \class ITKToolsCombineSegmentationsBase

--- a/src/combinesegmentations/itkLabelVoting2ImageFilter.txx
+++ b/src/combinesegmentations/itkLabelVoting2ImageFilter.txx
@@ -99,7 +99,7 @@ namespace itk
     }
 
     /** For multithreading: */
-    unsigned int numberOfThreads = this->GetNumberOfThreads();
+    unsigned int numberOfThreads = this->GetNumberOfWorkUnits();
     this->m_ConfusionMatrixArrays.resize( numberOfThreads );
     for( unsigned int t = 0; t < numberOfThreads; ++t)
     {
@@ -355,7 +355,7 @@ namespace itk
     {
 
       /** Add the confusion matrix arrays of all threads */
-      for( unsigned int t = 0; t < this->GetNumberOfThreads(); ++t )
+      for( unsigned int t = 0; t < this->GetNumberOfWorkUnits(); ++t )
       {
         for( unsigned int i = 0; i < numberOfInputs; ++i )
         {

--- a/src/combinesegmentations/itkLabelVoting2ImageFilter.txx
+++ b/src/combinesegmentations/itkLabelVoting2ImageFilter.txx
@@ -66,7 +66,7 @@ namespace itk
         ( this->GetInput( k ), this->GetInput( k )->GetBufferedRegion() );
 
       for ( it.GoToBegin(); !it.IsAtEnd(); ++it )
-        maxLabel = vnl_math_max( maxLabel, it.Get() );
+        maxLabel = std::max( maxLabel, it.Get() );
     }
 
     return maxLabel;

--- a/src/combinesegmentations/itkMultiLabelSTAPLE2ImageFilter.txx
+++ b/src/combinesegmentations/itkMultiLabelSTAPLE2ImageFilter.txx
@@ -72,7 +72,7 @@ namespace itk
         ( this->GetInput( k ), this->GetInput( k )->GetBufferedRegion() );
 
       for ( it.GoToBegin(); !it.IsAtEnd(); ++it )
-        maxLabel = vnl_math_max( maxLabel, it.Get() );
+        maxLabel = std::max( maxLabel, it.Get() );
     }
 
     return maxLabel;
@@ -471,7 +471,7 @@ namespace itk
       {
         const WeightsType maximumUpdate_k = static_cast<WeightsType>(
           (this->m_UpdatedConfusionMatrixArray[k]-this->m_ConfusionMatrixArray[k]).array_inf_norm() );
-        maximumUpdate = vnl_math_max( maximumUpdate, maximumUpdate_k );
+        maximumUpdate = std::max( maximumUpdate, maximumUpdate_k );
 
         this->m_ConfusionMatrixArray[k] = this->m_UpdatedConfusionMatrixArray[k];
       }

--- a/src/combinesegmentations/itkMultiLabelSTAPLEImageFilter.txx
+++ b/src/combinesegmentations/itkMultiLabelSTAPLEImageFilter.txx
@@ -55,7 +55,7 @@ namespace itk
         ( this->GetInput( k ), this->GetInput( k )->GetBufferedRegion() );
 
       for ( it.GoToBegin(); !it.IsAtEnd(); ++it )
-        maxLabel = vnl_math_max( maxLabel, it.Get() );
+        maxLabel = std::max( maxLabel, it.Get() );
     }
 
     return maxLabel;
@@ -313,7 +313,7 @@ namespace itk
               fabs( this->m_UpdatedConfusionMatrixArray[k][j][ci] -
               this->m_ConfusionMatrixArray[k][j][ci] );
 
-            maximumUpdate = vnl_math_max( maximumUpdate, thisParameterUpdate );
+            maximumUpdate = std::max( maximumUpdate, thisParameterUpdate );
 
             this->m_ConfusionMatrixArray[k][j][ci] =
               this->m_UpdatedConfusionMatrixArray[k][j][ci];

--- a/src/common/ITKToolsBase.h
+++ b/src/common/ITKToolsBase.h
@@ -31,7 +31,7 @@ namespace itktools
 
 #define itktoolsOneTypeNewMacro( object )                                       \
 static object * New( unsigned int dim,                                          \
-  itk::ImageIOBase::IOComponentType componentType )                             \
+  itk::ImageIOBase::IOComponentEnum componentType )                             \
 {                                                                               \
   if( VDimension == dim                                                         \
     && itktools::IsType<TComponentType>( componentType ) )                      \
@@ -43,8 +43,8 @@ static object * New( unsigned int dim,                                          
 
 #define itktoolsTwoTypeNewMacro( object )                                       \
 static object * New( unsigned int dim,                                          \
-  itk::ImageIOBase::IOComponentType inputComponentType,                         \
-  itk::ImageIOBase::IOComponentType outputComponentType )                       \
+  itk::ImageIOBase::IOComponentEnum inputComponentType,                         \
+  itk::ImageIOBase::IOComponentEnum outputComponentType )                       \
 {                                                                               \
   if( VDimension == dim                                                         \
     && itktools::IsType<TInputComponentType>( inputComponentType )              \
@@ -57,9 +57,9 @@ static object * New( unsigned int dim,                                          
 
 #define itktoolsThreeTypeNewMacro( object )                                     \
 static object * New( unsigned int dim,                                          \
-  itk::ImageIOBase::IOComponentType inputComponentType1,                        \
-  itk::ImageIOBase::IOComponentType inputComponentType2,                        \
-  itk::ImageIOBase::IOComponentType outputComponentType )                       \
+  itk::ImageIOBase::IOComponentEnum inputComponentType1,                        \
+  itk::ImageIOBase::IOComponentEnum inputComponentType2,                        \
+  itk::ImageIOBase::IOComponentEnum outputComponentType )                       \
 {                                                                               \
   if( VDimension == dim                                                         \
     && itktools::IsType<TInputComponentType1>( inputComponentType1 )            \

--- a/src/common/ITKToolsHelpers.cxx
+++ b/src/common/ITKToolsHelpers.cxx
@@ -111,10 +111,10 @@ bool ComponentTypeIsInteger( const itk::ImageIOBase::IOComponentEnum & component
 {
   /** Check if the input image is of integer type. */
   bool componentIsInteger = false;
-  if( componentType == itk::ImageIOBase::UCHAR  || componentType == itk::ImageIOBase::CHAR
-    || componentType == itk::ImageIOBase::USHORT || componentType == itk::ImageIOBase::SHORT
-    || componentType == itk::ImageIOBase::UINT   || componentType == itk::ImageIOBase::INT
-    || componentType == itk::ImageIOBase::ULONG  || componentType == itk::ImageIOBase::LONG )
+  if( componentType == itk::IOComponentEnum::UCHAR  || componentType == itk::IOComponentEnum::CHAR
+    || componentType == itk::IOComponentEnum::USHORT || componentType == itk::IOComponentEnum::SHORT
+    || componentType == itk::IOComponentEnum::UINT   || componentType == itk::IOComponentEnum::INT
+    || componentType == itk::IOComponentEnum::ULONG  || componentType == itk::IOComponentEnum::LONG )
   {
     componentIsInteger = true;
   }
@@ -131,16 +131,16 @@ bool ComponentTypeIsInteger( const itk::ImageIOBase::IOComponentEnum & component
 bool ComponentTypeIsValid( const itk::ImageIOBase::IOComponentEnum & componentType )
 {
   /** Check argument. */
-  if( componentType == itk::ImageIOBase::UCHAR
-    || componentType == itk::ImageIOBase::CHAR
-    || componentType == itk::ImageIOBase::USHORT
-    || componentType == itk::ImageIOBase::SHORT
-    || componentType == itk::ImageIOBase::UINT
-    || componentType == itk::ImageIOBase::INT
-    || componentType == itk::ImageIOBase::ULONG
-    || componentType == itk::ImageIOBase::LONG
-    || componentType == itk::ImageIOBase::FLOAT
-    || componentType == itk::ImageIOBase::DOUBLE )
+  if( componentType == itk::IOComponentEnum::UCHAR
+    || componentType == itk::IOComponentEnum::CHAR
+    || componentType == itk::IOComponentEnum::USHORT
+    || componentType == itk::IOComponentEnum::SHORT
+    || componentType == itk::IOComponentEnum::UINT
+    || componentType == itk::IOComponentEnum::INT
+    || componentType == itk::IOComponentEnum::ULONG
+    || componentType == itk::IOComponentEnum::LONG
+    || componentType == itk::IOComponentEnum::FLOAT
+    || componentType == itk::IOComponentEnum::DOUBLE )
   {
     return true;
   }
@@ -157,21 +157,21 @@ bool ComponentTypeIsValid( const itk::ImageIOBase::IOComponentEnum & componentTy
 itk::ImageIOBase::IOComponentEnum RemoveUnsignedFromComponentType(
   const itk::ImageIOBase::IOComponentEnum & componentType )
 {
-  if( componentType == itk::ImageIOBase::UCHAR )
+  if( componentType == itk::IOComponentEnum::UCHAR )
   {
-    return itk::ImageIOBase::CHAR;
+    return itk::IOComponentEnum::CHAR;
   }
-  else if( componentType == itk::ImageIOBase::UINT )
+  else if( componentType == itk::IOComponentEnum::UINT )
   {
-    return itk::ImageIOBase::INT;
+    return itk::IOComponentEnum::INT;
   }
-  else if( componentType == itk::ImageIOBase::USHORT )
+  else if( componentType == itk::IOComponentEnum::USHORT )
   {
-    return itk::ImageIOBase::SHORT;
+    return itk::IOComponentEnum::SHORT;
   }
-  else if( componentType == itk::ImageIOBase::ULONG )
+  else if( componentType == itk::IOComponentEnum::ULONG )
   {
-    return itk::ImageIOBase::LONG;
+    return itk::IOComponentEnum::LONG;
   }
 
   return componentType;
@@ -193,12 +193,12 @@ itk::ImageIOBase::IOComponentEnum GetLargestComponentType(
 
   /** Define the ranking. */
   RankingType ranking;
-  ranking.insert( EntryType( itk::ImageIOBase::CHAR,   1 ) );
-  ranking.insert( EntryType( itk::ImageIOBase::SHORT,  2 ) );
-  ranking.insert( EntryType( itk::ImageIOBase::INT,    3 ) );
-  ranking.insert( EntryType( itk::ImageIOBase::LONG,   4 ) );
-  ranking.insert( EntryType( itk::ImageIOBase::FLOAT,  5 ) );
-  ranking.insert( EntryType( itk::ImageIOBase::DOUBLE, 6 ) );
+  ranking.insert( EntryType( itk::IOComponentEnum::CHAR,   1 ) );
+  ranking.insert( EntryType( itk::IOComponentEnum::SHORT,  2 ) );
+  ranking.insert( EntryType( itk::IOComponentEnum::INT,    3 ) );
+  ranking.insert( EntryType( itk::IOComponentEnum::LONG,   4 ) );
+  ranking.insert( EntryType( itk::IOComponentEnum::FLOAT,  5 ) );
+  ranking.insert( EntryType( itk::IOComponentEnum::DOUBLE, 6 ) );
 
   /** Remove unsigned. */
   itk::ImageIOBase::IOComponentEnum type1Cleaned = RemoveUnsignedFromComponentType( type1 );

--- a/src/common/ITKToolsHelpers.cxx
+++ b/src/common/ITKToolsHelpers.cxx
@@ -107,7 +107,7 @@ void RemoveUnsignedFromString( std::string & arg )
  * ******************* ComponentTypeIsInteger *******************
  */
 
-bool ComponentTypeIsInteger( const itk::ImageIOBase::IOComponentType & componentType )
+bool ComponentTypeIsInteger( const itk::ImageIOBase::IOComponentEnum & componentType )
 {
   /** Check if the input image is of integer type. */
   bool componentIsInteger = false;
@@ -128,7 +128,7 @@ bool ComponentTypeIsInteger( const itk::ImageIOBase::IOComponentType & component
  * *************** ComponentTypeIsValid ***********************
  */
 
-bool ComponentTypeIsValid( const itk::ImageIOBase::IOComponentType & componentType )
+bool ComponentTypeIsValid( const itk::ImageIOBase::IOComponentEnum & componentType )
 {
   /** Check argument. */
   if( componentType == itk::ImageIOBase::UCHAR
@@ -154,8 +154,8 @@ bool ComponentTypeIsValid( const itk::ImageIOBase::IOComponentType & componentTy
  * *************** RemoveUnsignedFromComponentType ***********************
  */
 
-itk::ImageIOBase::IOComponentType RemoveUnsignedFromComponentType(
-  const itk::ImageIOBase::IOComponentType & componentType )
+itk::ImageIOBase::IOComponentEnum RemoveUnsignedFromComponentType(
+  const itk::ImageIOBase::IOComponentEnum & componentType )
 {
   if( componentType == itk::ImageIOBase::UCHAR )
   {
@@ -183,12 +183,12 @@ itk::ImageIOBase::IOComponentType RemoveUnsignedFromComponentType(
  * *************** GetLargestComponentType ***********************
  */
 
-itk::ImageIOBase::IOComponentType GetLargestComponentType(
-  const itk::ImageIOBase::IOComponentType & type1,
-  const itk::ImageIOBase::IOComponentType & type2 )
+itk::ImageIOBase::IOComponentEnum GetLargestComponentType(
+  const itk::ImageIOBase::IOComponentEnum & type1,
+  const itk::ImageIOBase::IOComponentEnum & type2 )
 {
   /** Typedef's. */
-  typedef std::map< itk::ImageIOBase::IOComponentType, unsigned int > RankingType;
+  typedef std::map< itk::ImageIOBase::IOComponentEnum, unsigned int > RankingType;
   typedef RankingType::value_type               EntryType;
 
   /** Define the ranking. */
@@ -201,11 +201,11 @@ itk::ImageIOBase::IOComponentType GetLargestComponentType(
   ranking.insert( EntryType( itk::ImageIOBase::DOUBLE, 6 ) );
 
   /** Remove unsigned. */
-  itk::ImageIOBase::IOComponentType type1Cleaned = RemoveUnsignedFromComponentType( type1 );
-  itk::ImageIOBase::IOComponentType type2Cleaned = RemoveUnsignedFromComponentType( type2 );
+  itk::ImageIOBase::IOComponentEnum type1Cleaned = RemoveUnsignedFromComponentType( type1 );
+  itk::ImageIOBase::IOComponentEnum type2Cleaned = RemoveUnsignedFromComponentType( type2 );
 
   /** Determine which one is the largest. */
-  itk::ImageIOBase::IOComponentType outputComponentType;
+  itk::ImageIOBase::IOComponentEnum outputComponentType;
   if( type1Cleaned == type2Cleaned )
   {
     outputComponentType = type1;
@@ -228,7 +228,7 @@ itk::ImageIOBase::IOComponentType GetLargestComponentType(
 bool IsFilterSupportedCheck(
   const ITKToolsBase * filter,
   const unsigned int & dim,
-  const itk::ImageIOBase::IOComponentType & inputType )
+  const itk::ImageIOBase::IOComponentEnum & inputType )
 {
   if( !filter )
   {
@@ -251,8 +251,8 @@ bool IsFilterSupportedCheck(
 bool IsFilterSupportedCheck(
   const ITKToolsBase * filter,
   const unsigned int & dim,
-  const itk::ImageIOBase::IOComponentType & inputType,
-  const itk::ImageIOBase::IOComponentType & outputType )
+  const itk::ImageIOBase::IOComponentEnum & inputType,
+  const itk::ImageIOBase::IOComponentEnum & outputType )
 {
   if( !filter )
   {
@@ -276,9 +276,9 @@ bool IsFilterSupportedCheck(
 bool IsFilterSupportedCheck(
   const ITKToolsBase * filter,
   const unsigned int & dim,
-  const itk::ImageIOBase::IOComponentType & inputType1,
-  const itk::ImageIOBase::IOComponentType & inputType2,
-  const itk::ImageIOBase::IOComponentType & outputType )
+  const itk::ImageIOBase::IOComponentEnum & inputType1,
+  const itk::ImageIOBase::IOComponentEnum & inputType2,
+  const itk::ImageIOBase::IOComponentEnum & outputType )
 {
   if( !filter )
   {

--- a/src/common/ITKToolsHelpers.h
+++ b/src/common/ITKToolsHelpers.h
@@ -34,7 +34,7 @@ std::string GetITKToolsVersion( void );
 
 /** Test if a ComponentType corresponds to the template parameter. */
 template <class T>
-bool IsType( itk::ImageIOBase::IOComponentType ct )
+bool IsType( itk::ImageIOBase::IOComponentEnum ct )
 {
   return ct == itk::ImageIOBase::MapPixelType<T>::CType;
 }
@@ -53,42 +53,42 @@ void RemoveUnsignedFromString( std::string & arg );
 
 /** ComponentTypeIsInteger. */
 bool ComponentTypeIsInteger(
-  const itk::ImageIOBase::IOComponentType & inputComponentType );
+  const itk::ImageIOBase::IOComponentEnum & inputComponentType );
 
 /** Remove "unsigned " or "unsigned_" from the component type. */
-itk::ImageIOBase::IOComponentType RemoveUnsignedFromComponentType(
-  const itk::ImageIOBase::IOComponentType & componentType );
+itk::ImageIOBase::IOComponentEnum RemoveUnsignedFromComponentType(
+  const itk::ImageIOBase::IOComponentEnum & componentType );
 
 /** Check for a valid component type. */
-bool ComponentTypeIsValid( const itk::ImageIOBase::IOComponentType & arg );
+bool ComponentTypeIsValid( const itk::ImageIOBase::IOComponentEnum & arg );
 
 /** Selects the largest type of the two. The order is:
  * char < short < int < long < float < double.
  */
-itk::ImageIOBase::IOComponentType GetLargestComponentType(
-  const itk::ImageIOBase::IOComponentType & type1,
-  const itk::ImageIOBase::IOComponentType & type2 );
+itk::ImageIOBase::IOComponentEnum GetLargestComponentType(
+  const itk::ImageIOBase::IOComponentEnum & type1,
+  const itk::ImageIOBase::IOComponentEnum & type2 );
 
 /** IsFilterSupportedCheck. Unify error message printing. */
 bool IsFilterSupportedCheck(
   const ITKToolsBase * filter,
   const unsigned int & dim,
-  const itk::ImageIOBase::IOComponentType & inputType );
+  const itk::ImageIOBase::IOComponentEnum & inputType );
 
 /** IsFilterSupportedCheck. Unify error message printing. */
 bool IsFilterSupportedCheck(
   const ITKToolsBase * filter,
   const unsigned int & dim,
-  const itk::ImageIOBase::IOComponentType & inputType,
-  const itk::ImageIOBase::IOComponentType & outputType );
+  const itk::ImageIOBase::IOComponentEnum & inputType,
+  const itk::ImageIOBase::IOComponentEnum & outputType );
 
 /** IsFilterSupportedCheck. Unify error message printing. */
 bool IsFilterSupportedCheck(
   const ITKToolsBase * filter,
   const unsigned int & dim,
-  const itk::ImageIOBase::IOComponentType & inputType1,
-  const itk::ImageIOBase::IOComponentType & inputType2,
-  const itk::ImageIOBase::IOComponentType & outputType );
+  const itk::ImageIOBase::IOComponentEnum & inputType1,
+  const itk::ImageIOBase::IOComponentEnum & inputType2,
+  const itk::ImageIOBase::IOComponentEnum & outputType );
 
 /** NumberOfComponentsCheck. Unify error message printing. */
 bool NumberOfComponentsCheck( const unsigned int & numberOfComponents );

--- a/src/common/ITKToolsImageProperties.cxx
+++ b/src/common/ITKToolsImageProperties.cxx
@@ -70,7 +70,7 @@ itk::ImageIOBase::IOComponentEnum GetImageComponentType( const std::string & fil
     filename.c_str(), itk::ImageIOFactory::ReadMode);
   if( imageIO.IsNull() )
   {
-    return itk::ImageIOBase::UNKNOWNCOMPONENTTYPE; // complain
+    return itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE; // complain
   }
   imageIO->SetFileName( filename.c_str() );
   imageIO->ReadImageInformation();

--- a/src/common/ITKToolsImageProperties.cxx
+++ b/src/common/ITKToolsImageProperties.cxx
@@ -67,7 +67,7 @@ bool GetImageComponentType(
 itk::ImageIOBase::IOComponentEnum GetImageComponentType( const std::string & filename )
 {
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-    filename.c_str(), itk::ImageIOFactory::ReadMode);
+    filename.c_str(), itk::IOFileModeEnum::ReadMode);
   if( imageIO.IsNull() )
   {
     return itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE; // complain

--- a/src/common/ITKToolsImageProperties.cxx
+++ b/src/common/ITKToolsImageProperties.cxx
@@ -48,7 +48,7 @@ bool GetImagePixelType(
 
 bool GetImageComponentType(
   const std::string & filename,
-  itk::ImageIOBase::IOComponentType & componentType )
+  itk::ImageIOBase::IOComponentEnum & componentType )
 {
   itk::ImageIOBase::Pointer imageIOBase;
   GetImageIOBase( filename, imageIOBase );
@@ -64,7 +64,7 @@ bool GetImageComponentType(
  * ***************** GetImageComponentType ************************
  */
 
-itk::ImageIOBase::IOComponentType GetImageComponentType( const std::string & filename )
+itk::ImageIOBase::IOComponentEnum GetImageComponentType( const std::string & filename )
 {
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
     filename.c_str(), itk::ImageIOFactory::ReadMode);
@@ -225,7 +225,7 @@ bool GetImageDirection(
 bool GetImageProperties(
   const std::string & fileName,
   itk::ImageIOBase::IOPixelType & pixelType,
-  itk::ImageIOBase::IOComponentType & componentType,
+  itk::ImageIOBase::IOComponentEnum & componentType,
   unsigned int & dimension,
   unsigned int & numberOfComponents )
 {
@@ -277,7 +277,7 @@ int GetImageProperties(
 
 int GetImageProperties(
   const std::string & filename,
-  itk::ImageIOBase::IOComponentType & componentType,
+  itk::ImageIOBase::IOComponentEnum & componentType,
   unsigned int & dimension,
   unsigned int & numberOfComponents,
   std::vector<unsigned int> & imageSize )
@@ -303,7 +303,7 @@ int GetImageProperties(
 bool GetImageProperties(
   const std::string & fileName,
   itk::ImageIOBase::IOPixelType & pixelType,
-  itk::ImageIOBase::IOComponentType & componentType,
+  itk::ImageIOBase::IOComponentEnum & componentType,
   unsigned int & dimension,
   unsigned int & numberOfComponents,
   std::vector<unsigned int> & imageSize )
@@ -330,7 +330,7 @@ bool GetImageProperties(
 bool GetImageProperties(
   const std::string & fileName,
   itk::ImageIOBase::IOPixelType & pixelType,
-  itk::ImageIOBase::IOComponentType & componentType,
+  itk::ImageIOBase::IOComponentEnum & componentType,
   unsigned int & dimension,
   unsigned int & numberOfComponents,
   std::vector<unsigned int> & imageSize,
@@ -448,7 +448,7 @@ void FillImageIOBase( itk::ImageIOBase::Pointer & imageIOBase,
   imageIOBase->SetPixelType( pixelType );
 
   /** Set component type. */
-  itk::ImageIOBase::IOComponentType componentType
+  itk::ImageIOBase::IOComponentEnum componentType
     = itk::ImageIOBase::GetComponentTypeFromString( componentTypeAsString );
   imageIOBase->SetComponentType( componentType );
 

--- a/src/common/ITKToolsImageProperties.cxx
+++ b/src/common/ITKToolsImageProperties.cxx
@@ -224,7 +224,7 @@ bool GetImageDirection(
 
 bool GetImageProperties(
   const std::string & fileName,
-  itk::ImageIOBase::IOPixelType & pixelType,
+  itk::IOPixelEnum & pixelType,
   itk::ImageIOBase::IOComponentEnum & componentType,
   unsigned int & dimension,
   unsigned int & numberOfComponents )
@@ -302,7 +302,7 @@ int GetImageProperties(
 
 bool GetImageProperties(
   const std::string & fileName,
-  itk::ImageIOBase::IOPixelType & pixelType,
+  itk::IOPixelEnum & pixelType,
   itk::ImageIOBase::IOComponentEnum & componentType,
   unsigned int & dimension,
   unsigned int & numberOfComponents,
@@ -329,7 +329,7 @@ bool GetImageProperties(
 
 bool GetImageProperties(
   const std::string & fileName,
-  itk::ImageIOBase::IOPixelType & pixelType,
+  itk::IOPixelEnum & pixelType,
   itk::ImageIOBase::IOComponentEnum & componentType,
   unsigned int & dimension,
   unsigned int & numberOfComponents,
@@ -443,7 +443,7 @@ void FillImageIOBase( itk::ImageIOBase::Pointer & imageIOBase,
   imageIOBase->SetNumberOfComponents( numberOfComponents );
 
   /** Set pixel type. */
-  itk::ImageIOBase::IOPixelType pixelType
+  itk::IOPixelEnum pixelType
     = itk::ImageIOBase::GetPixelTypeFromString( pixelTypeAsString );
   imageIOBase->SetPixelType( pixelType );
 

--- a/src/common/ITKToolsImageProperties.h
+++ b/src/common/ITKToolsImageProperties.h
@@ -33,10 +33,10 @@ bool GetImagePixelType(
 /** Determine componenttype (short, float etc) of an image */
 bool GetImageComponentType(
   const std::string & filename,
-  itk::ImageIOBase::IOComponentType & componenttype );
+  itk::ImageIOBase::IOComponentEnum & componenttype );
 
 /** Determine the component type of an image. */
-itk::ImageIOBase::IOComponentType GetImageComponentType(
+itk::ImageIOBase::IOComponentEnum GetImageComponentType(
   const std::string & filename );
 
 /** Determine the number of components of each pixel in an image. */
@@ -81,7 +81,7 @@ bool GetImageDirection(
 bool GetImageProperties(
   const std::string & filename,
   itk::ImageIOBase::IOPixelType & pixeltype,
-  itk::ImageIOBase::IOComponentType & componenttype,
+  itk::ImageIOBase::IOComponentEnum & componenttype,
   unsigned int & dimension,
   unsigned int & numberofcomponents );
 
@@ -104,7 +104,7 @@ int GetImageProperties(
 bool GetImageProperties(
   const std::string & filename,
   itk::ImageIOBase::IOPixelType & pixeltype,
-  itk::ImageIOBase::IOComponentType & componenttype,
+  itk::ImageIOBase::IOComponentEnum & componenttype,
   unsigned int & dimension,
   unsigned int & numberofcomponents,
   std::vector<unsigned int> & imagesize );
@@ -112,7 +112,7 @@ bool GetImageProperties(
 bool GetImageProperties(
   const std::string & filename,
   itk::ImageIOBase::IOPixelType & pixeltype,
-  itk::ImageIOBase::IOComponentType & componenttype,
+  itk::ImageIOBase::IOComponentEnum & componenttype,
   unsigned int & dimension,
   unsigned int & numberofcomponents,
   std::vector<unsigned int> & size,
@@ -126,7 +126,7 @@ bool GetImageProperties(
  */
 int GetImageProperties(
   const std::string & filename,
-  itk::ImageIOBase::IOComponentType & componenttype,
+  itk::ImageIOBase::IOComponentEnum & componenttype,
   unsigned int & dimension,
   unsigned int & numberofcomponents,
   std::vector<unsigned int> & imagesize );

--- a/src/common/ITKToolsImageProperties.h
+++ b/src/common/ITKToolsImageProperties.h
@@ -80,7 +80,7 @@ bool GetImageDirection(
  */
 bool GetImageProperties(
   const std::string & filename,
-  itk::ImageIOBase::IOPixelType & pixeltype,
+  itk::IOPixelEnum & pixeltype,
   itk::ImageIOBase::IOComponentEnum & componenttype,
   unsigned int & dimension,
   unsigned int & numberofcomponents );
@@ -103,7 +103,7 @@ int GetImageProperties(
  */
 bool GetImageProperties(
   const std::string & filename,
-  itk::ImageIOBase::IOPixelType & pixeltype,
+  itk::IOPixelEnum & pixeltype,
   itk::ImageIOBase::IOComponentEnum & componenttype,
   unsigned int & dimension,
   unsigned int & numberofcomponents,
@@ -111,7 +111,7 @@ bool GetImageProperties(
 
 bool GetImageProperties(
   const std::string & filename,
-  itk::ImageIOBase::IOPixelType & pixeltype,
+  itk::IOPixelEnum & pixeltype,
   itk::ImageIOBase::IOComponentEnum & componenttype,
   unsigned int & dimension,
   unsigned int & numberofcomponents,

--- a/src/computeboundingbox/computeboundingbox.cxx
+++ b/src/computeboundingbox/computeboundingbox.cxx
@@ -79,7 +79,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-in", inputFileName );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/computeboundingbox/computeboundingbox.cxx
+++ b/src/computeboundingbox/computeboundingbox.cxx
@@ -80,7 +80,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(
@@ -94,7 +94,7 @@ int main( int argc, char **argv )
   /** Overrule component type, since only short will do something,
    * and it is not relevant in this case.
    */
-  componentType = itk::ImageIOBase::SHORT;
+  componentType = itk::IOComponentEnum::SHORT;
 
   /** Class that does the work. */
   ITKToolsComputeBoundingBoxBase * filter = 0;

--- a/src/computeboundingbox/computeboundingbox.cxx
+++ b/src/computeboundingbox/computeboundingbox.cxx
@@ -79,7 +79,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-in", inputFileName );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/computeboundingbox/computeboundingbox.cxx
+++ b/src/computeboundingbox/computeboundingbox.cxx
@@ -80,7 +80,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/computeboundingbox/computeboundingbox.h
+++ b/src/computeboundingbox/computeboundingbox.h
@@ -108,7 +108,7 @@ public:
         const IndexType & index = iterator.GetIndex();
         for( unsigned int i = 0; i < dimension; ++i )
         {
-          minIndex[ i ] = vnl_math_min( index[ i ], minIndex[ i ] );
+          minIndex[ i ] = std::min( index[ i ], minIndex[ i ] );
           maxIndex[ i ] = std::max( index[ i ], maxIndex[ i ] );
         }
       }

--- a/src/computeboundingbox/computeboundingbox.h
+++ b/src/computeboundingbox/computeboundingbox.h
@@ -109,7 +109,7 @@ public:
         for( unsigned int i = 0; i < dimension; ++i )
         {
           minIndex[ i ] = vnl_math_min( index[ i ], minIndex[ i ] );
-          maxIndex[ i ] = vnl_math_max( index[ i ], maxIndex[ i ] );
+          maxIndex[ i ] = std::max( index[ i ], maxIndex[ i ] );
         }
       }
       ++iterator;

--- a/src/computeoverlap/ComputeOverlapOld.h
+++ b/src/computeoverlap/ComputeOverlapOld.h
@@ -111,10 +111,10 @@ public:
     finalANDFilter->SetDirectionTolerance( this->m_Tolerance );
 
     /** Create images, threshold filters, and threshold vectors. */
-    ImagePointer im1 = 0;
-    ImagePointer im2 = 0;
-    ThresholdFilterPointer thresholder1 = 0;
-    ThresholdFilterPointer thresholder2 = 0;
+    ImagePointer im1 = nullptr;
+    ImagePointer im2 = nullptr;
+    ThresholdFilterPointer thresholder1 = nullptr;
+    ThresholdFilterPointer thresholder2 = nullptr;
     ThresholdVectorType thresholdVector1( 2 );
     ThresholdVectorType thresholdVector2( 2 );
 
@@ -154,10 +154,10 @@ public:
     }
 
     /** Create readers for the masks and AND filters. */
-    ImageReaderPointer maskReader1 = 0;
-    ImageReaderPointer maskReader2 = 0;
-    AndFilterPointer im2ANDmask1Filter = 0;
-    AndFilterPointer im1ANDmask2Filter = 0;
+    ImageReaderPointer maskReader1 = nullptr;
+    ImageReaderPointer maskReader2 = nullptr;
+    AndFilterPointer im2ANDmask1Filter = nullptr;
+    AndFilterPointer im1ANDmask2Filter = nullptr;
 
     /** If there is a mask given for image1, use it on image2. */
     if( this->m_MaskFileName1 != "" )

--- a/src/computeoverlap/computeoverlap.cxx
+++ b/src/computeoverlap/computeoverlap.cxx
@@ -124,7 +124,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/computeoverlap/computeoverlap.cxx
+++ b/src/computeoverlap/computeoverlap.cxx
@@ -123,7 +123,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/computeoverlap/computeoverlap.cxx
+++ b/src/computeoverlap/computeoverlap.cxx
@@ -123,7 +123,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/computeoverlap/computeoverlap.cxx
+++ b/src/computeoverlap/computeoverlap.cxx
@@ -124,7 +124,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/computeoverlap/itkDiceOverlapImageFilter.txx
+++ b/src/computeoverlap/itkDiceOverlapImageFilter.txx
@@ -53,7 +53,7 @@ void
 DiceOverlapImageFilter<TInputImage>
 ::BeforeThreadedGenerateData( void )
 {
-  const int numberOfThreads = this->GetNumberOfThreads();
+  const int numberOfThreads = this->GetNumberOfWorkUnits();
 
   // Create the thread temporaries
   this->m_SumAForThread.resize( numberOfThreads );
@@ -124,7 +124,7 @@ DiceOverlapImageFilter<TInputImage>
   OverlapMapType sumB = this->m_SumBForThread[ 0 ];
   OverlapMapType sumC = this->m_SumCForThread[ 0 ];
   typename OverlapMapType::const_iterator  it;
-  for( unsigned int threadId = 1; threadId < this->GetNumberOfThreads(); threadId++ )
+  for( unsigned int threadId = 1; threadId < this->GetNumberOfWorkUnits(); threadId++ )
   {
     for( it = this->m_SumAForThread[ threadId ].begin(); it != this->m_SumAForThread[ threadId ].end(); ++it )
     {

--- a/src/computeoverlapsummary/computeoverlapsummary.cxx
+++ b/src/computeoverlapsummary/computeoverlapsummary.cxx
@@ -99,7 +99,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/computeoverlapsummary/computeoverlapsummary.cxx
+++ b/src/computeoverlapsummary/computeoverlapsummary.cxx
@@ -98,7 +98,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/computeoverlapsummary/computeoverlapsummary.cxx
+++ b/src/computeoverlapsummary/computeoverlapsummary.cxx
@@ -99,7 +99,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/computeoverlapsummary/computeoverlapsummary.cxx
+++ b/src/computeoverlapsummary/computeoverlapsummary.cxx
@@ -98,7 +98,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/computeoverlapsummary/computeoverlapsummary.h
+++ b/src/computeoverlapsummary/computeoverlapsummary.h
@@ -99,7 +99,7 @@ public:
     FILE * pFile;
     pFile = fopen( this->m_OutputFileName.c_str(), "w" );
 
-    if( pFile == NULL )
+    if( pFile == nullptr )
     {
       throw invalidfilexception();
     }

--- a/src/contrastenhanceimage/contrastenhanceimage.cxx
+++ b/src/contrastenhanceimage/contrastenhanceimage.cxx
@@ -106,7 +106,7 @@ int main( int argc, char** argv )
   parser->GetCommandLineArgument( "-r", radius );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/contrastenhanceimage/contrastenhanceimage.cxx
+++ b/src/contrastenhanceimage/contrastenhanceimage.cxx
@@ -106,7 +106,7 @@ int main( int argc, char** argv )
   parser->GetCommandLineArgument( "-r", radius );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/contrastenhanceimage/contrastenhanceimage.cxx
+++ b/src/contrastenhanceimage/contrastenhanceimage.cxx
@@ -107,7 +107,7 @@ int main( int argc, char** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/contrastenhanceimage/contrastenhanceimage.cxx
+++ b/src/contrastenhanceimage/contrastenhanceimage.cxx
@@ -107,7 +107,7 @@ int main( int argc, char** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/contrastenhanceimage/contrastenhanceimage.cxx
+++ b/src/contrastenhanceimage/contrastenhanceimage.cxx
@@ -115,7 +115,7 @@ int main( int argc, char** argv )
   if( !retgip ) return EXIT_FAILURE;
 
   /** Class that does the work. */
-  ITKToolsContrastEnhanceImageBase * filter = NULL;
+  ITKToolsContrastEnhanceImageBase * filter = nullptr;
 
   try
   {

--- a/src/createbox/createbox.cxx
+++ b/src/createbox/createbox.cxx
@@ -207,7 +207,7 @@ int main( int argc, char** argv )
   /** Let the user overrule this. */
   bool retopct = parser->GetCommandLineArgument( "-opct", componentTypeAsString );
 
-  itk::ImageIOBase::IOComponentType componentType
+  itk::ImageIOBase::IOComponentEnum componentType
     = referenceIOBase->GetComponentTypeFromString( componentTypeAsString );
 
   /** How was the input supplied by the user? */

--- a/src/createbox/createbox.h
+++ b/src/createbox/createbox.h
@@ -157,7 +157,7 @@ public:
       for( unsigned int i = 0; i < VDimension; i++ )
       {
         Center[ i ] = ( point1[ i ] + point2[ i ] ) / 2.0;
-        Radius[ i ] = spacingITK[ i ] + vcl_abs( point1[ i ] - Center[ i ] );
+        Radius[ i ] = spacingITK[ i ] + std::abs( point1[ i ] - Center[ i ] );
       }
     }
     else

--- a/src/createbox/createbox.h
+++ b/src/createbox/createbox.h
@@ -40,7 +40,7 @@ public:
   /** Constructor. */
   ITKToolsCreateBoxBase()
   {
-    this->m_ReferenceImageIOBase = NULL;
+    this->m_ReferenceImageIOBase = nullptr;
     this->m_OutputFileName = "";
     this->m_BoxDefinition = "";
   }

--- a/src/createbox/itkBoxSpatialFunction.txx
+++ b/src/createbox/itkBoxSpatialFunction.txx
@@ -75,7 +75,7 @@ BoxSpatialFunction<VImageDimension,TInput>
   bool acc = true;
   for( unsigned int i = 0; i < ImageDimension; i++ )
   {
-    acc &= vcl_abs( mappedPosition[ i ] - this->m_Center[ i ] ) < this->m_Radius[ i ];
+    acc &= std::abs( mappedPosition[ i ] - this->m_Center[ i ] ) < this->m_Radius[ i ];
   }
 
   /** Return a value. */

--- a/src/createcylinder/createcylinder.cxx
+++ b/src/createcylinder/createcylinder.cxx
@@ -221,7 +221,7 @@ int main( int argc, char *argv[] )
 
 
   /** Class that does the work. */
-  ITKToolsCreateCylinderBase * createCylinder = NULL;
+  ITKToolsCreateCylinderBase * createCylinder = nullptr;
 
   /** Short alias */
   unsigned int dim = Dimension;

--- a/src/createellipsoid/createellipsoid.cxx
+++ b/src/createellipsoid/createellipsoid.cxx
@@ -100,7 +100,7 @@ int main( int argc, char *argv[] )
 
   std::string componentTypeAsString = "short";
   parser->GetCommandLineArgument( "-opct", componentTypeAsString );
-  itk::ImageIOBase::IOComponentType componentType
+  itk::ImageIOBase::IOComponentEnum componentType
     = itk::ImageIOBase::GetComponentTypeFromString( componentTypeAsString );
 
   std::vector<double> spacing( dim, 1.0 );

--- a/src/creategridimage/creategridimage.cxx
+++ b/src/creategridimage/creategridimage.cxx
@@ -290,7 +290,7 @@ int main( int argc, char *argv[] )
 
 
   /** Class that does the work. */
-  ITKToolsCreateGridImageBase * filter = NULL;
+  ITKToolsCreateGridImageBase * filter = nullptr;
 
   /** Short alias */
   unsigned int dim = imageDimension;

--- a/src/createrandomimage/createrandomimage.cxx
+++ b/src/createrandomimage/createrandomimage.cxx
@@ -142,7 +142,7 @@ int main( int argc, char** argv )
   itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::GetComponentTypeFromString( pixelType );
 
   /** Class that does the work. */
-  ITKToolsCreateRandomImageBase * filter = NULL;
+  ITKToolsCreateRandomImageBase * filter = nullptr;
 
   try
   {

--- a/src/createrandomimage/createrandomimage.cxx
+++ b/src/createrandomimage/createrandomimage.cxx
@@ -139,7 +139,7 @@ int main( int argc, char** argv )
   unsigned long resolution = nrOfPixels / 64;
   parser->GetCommandLineArgument( "-r", resolution );
 
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::GetComponentTypeFromString( pixelType );
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::GetComponentTypeFromString( pixelType );
 
   /** Class that does the work. */
   ITKToolsCreateRandomImageBase * filter = nullptr;

--- a/src/createrandomimage/createrandomimage.h
+++ b/src/createrandomimage/createrandomimage.h
@@ -32,7 +32,6 @@
 #include "itkCastImageFilter.h"
 #include "itkExtractImageFilter.h"
 #include "itkComposeImageFilter.h"
-#include "itkExceptionObject.h"
 #include "itkNumericTraits.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 #include <iostream>

--- a/src/createrandomimage/createrandomimage.h
+++ b/src/createrandomimage/createrandomimage.h
@@ -148,7 +148,7 @@ public:
     typedef RandomGeneratorType::Pointer RandomGeneratorPointer;
 
     /** Create variables */
-    VectorWriterPointer vectorWriter = 0;
+    VectorWriterPointer vectorWriter = nullptr;
 
     SetOfChannelsType setOfChannels( this->m_SpaceDimension );
     SetOfBlurrersType setOfBlurrers( this->m_SpaceDimension );

--- a/src/createsimplebox/createsimplebox.cxx
+++ b/src/createsimplebox/createsimplebox.cxx
@@ -129,7 +129,7 @@ int main( int argc, char** argv )
   }
 
   /** Class that does the work. */
-  ITKToolsCreateSimpleBoxBase * filter = NULL;
+  ITKToolsCreateSimpleBoxBase * filter = nullptr;
 
   try
   {

--- a/src/createsimplebox/createsimplebox.cxx
+++ b/src/createsimplebox/createsimplebox.cxx
@@ -115,7 +115,7 @@ int main( int argc, char** argv )
   std::vector<unsigned int> boxSize;
   parser->GetCommandLineArgument( "-d", boxSize );
 
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   if( retin ) // if an input file was specified
   {
     itktools::GetImageDimension( inputFileName, dim );

--- a/src/createsimplebox/createsimplebox.cxx
+++ b/src/createsimplebox/createsimplebox.cxx
@@ -115,7 +115,7 @@ int main( int argc, char** argv )
   std::vector<unsigned int> boxSize;
   parser->GetCommandLineArgument( "-d", boxSize );
 
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   if( retin ) // if an input file was specified
   {
     itktools::GetImageDimension( inputFileName, dim );

--- a/src/createsimplebox/createsimplebox.h
+++ b/src/createsimplebox/createsimplebox.h
@@ -158,9 +158,9 @@ public:
     {
       const double distance = pointB[ i ] - pointA[ i ];
       double sign = 1.0;
-      if( vcl_abs(distance) > small_number )
+      if( std::abs(distance) > small_number )
       {
-        sign = distance / vcl_abs( distance );
+        sign = distance / std::abs( distance );
       }
       pointA[ i ] -= small_factor * sign * spacing[ i ];
       pointB[ i ] += small_factor * sign * spacing[ i ];

--- a/src/createsphere/createsphere.cxx
+++ b/src/createsphere/createsphere.cxx
@@ -101,7 +101,7 @@ int main( int argc, char *argv[] )
   parser->GetCommandLineArgument( "-sp", spacing );
 
   /** String to component type. */
-  itk::ImageIOBase::IOComponentType componentType
+  itk::ImageIOBase::IOComponentEnum componentType
     = itk::ImageIOBase::GetComponentTypeFromString( componentTypeAsString );
 
   /** Class that does the work. */

--- a/src/createzeroimage/createzeroimage.cxx
+++ b/src/createzeroimage/createzeroimage.cxx
@@ -115,7 +115,7 @@ int main( int argc, char **argv )
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   if( retin )
   {
-    itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+    itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
     unsigned int dim = 0;
     unsigned int numberOfComponents = 0;
     bool retgip = itktools::GetImageProperties(

--- a/src/createzeroimage/createzeroimage.cxx
+++ b/src/createzeroimage/createzeroimage.cxx
@@ -115,7 +115,7 @@ int main( int argc, char **argv )
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   if( retin )
   {
-    itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+    itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
     unsigned int dim = 0;
     unsigned int numberOfComponents = 0;
     bool retgip = itktools::GetImageProperties(

--- a/src/createzeroimage/createzeroimage.cxx
+++ b/src/createzeroimage/createzeroimage.cxx
@@ -112,7 +112,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-d", direction );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   if( retin )
   {
     itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;

--- a/src/createzeroimage/createzeroimage.cxx
+++ b/src/createzeroimage/createzeroimage.cxx
@@ -112,7 +112,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-d", direction );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   if( retin )
   {
     itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;

--- a/src/cropimage/cropimage.cxx
+++ b/src/cropimage/cropimage.cxx
@@ -112,7 +112,7 @@ int main( int argc, char **argv )
   bool useCompression = parser->ArgumentExists( "-z" );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/cropimage/cropimage.cxx
+++ b/src/cropimage/cropimage.cxx
@@ -113,7 +113,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/cropimage/cropimage.cxx
+++ b/src/cropimage/cropimage.cxx
@@ -113,7 +113,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/cropimage/cropimage.cxx
+++ b/src/cropimage/cropimage.cxx
@@ -112,7 +112,7 @@ int main( int argc, char **argv )
   bool useCompression = parser->ArgumentExists( "-z" );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/cropimage/cropimageMainHelper.h
+++ b/src/cropimage/cropimageMainHelper.h
@@ -113,7 +113,7 @@ void GetBox( std::vector<int> & pA, std::vector<int> & pB, unsigned int dimensio
   for( unsigned int i = 0; i < dimension; i++ )
   {
     pa[ i ] = vnl_math_min( pA[ i ], pB[ i ] );
-    pb[ i ] = vnl_math_max( pA[ i ], pB[ i ] );
+    pb[ i ] = std::max( pA[ i ], pB[ i ] );
   }
 
   /** Copy to the input variables. */

--- a/src/cropimage/cropimageMainHelper.h
+++ b/src/cropimage/cropimageMainHelper.h
@@ -112,7 +112,7 @@ void GetBox( std::vector<int> & pA, std::vector<int> & pB, unsigned int dimensio
   std::vector<int> pb( dimension, 0 );
   for( unsigned int i = 0; i < dimension; i++ )
   {
-    pa[ i ] = vnl_math_min( pA[ i ], pB[ i ] );
+    pa[ i ] = std::min( pA[ i ], pB[ i ] );
     pb[ i ] = std::max( pA[ i ], pB[ i ] );
   }
 

--- a/src/deformationfieldgenerator/deformationfieldgenerator.cxx
+++ b/src/deformationfieldgenerator/deformationfieldgenerator.cxx
@@ -123,7 +123,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-s", stiffness );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/deformationfieldgenerator/deformationfieldgenerator.cxx
+++ b/src/deformationfieldgenerator/deformationfieldgenerator.cxx
@@ -124,7 +124,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/deformationfieldgenerator/deformationfieldgenerator.cxx
+++ b/src/deformationfieldgenerator/deformationfieldgenerator.cxx
@@ -124,7 +124,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/deformationfieldgenerator/deformationfieldgenerator.cxx
+++ b/src/deformationfieldgenerator/deformationfieldgenerator.cxx
@@ -123,7 +123,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-s", stiffness );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/deformationfieldgenerator/deformationfieldgenerator.cxx
+++ b/src/deformationfieldgenerator/deformationfieldgenerator.cxx
@@ -141,7 +141,7 @@ int main( int argc, char **argv )
   componentType = itk::ImageIOBase::GetComponentTypeFromString( componentTypeAsString );
 
   /** Class that does the work. */
-  ITKToolsDeformationFieldGeneratorBase * filter = NULL;
+  ITKToolsDeformationFieldGeneratorBase * filter = nullptr;
 
   try
   {

--- a/src/deformationfieldgenerator/deformationfieldgenerator.h
+++ b/src/deformationfieldgenerator/deformationfieldgenerator.h
@@ -214,7 +214,7 @@ public:
         inputPointSet1->GetPoint( j, &point );
         for ( unsigned int i = 0; i < VDimension; i++ )
         {
-          index[i] = static_cast< IndexValueType >( vnl_math_rnd( point[i] ) );
+          index[i] = static_cast< IndexValueType >( vnl_math::rnd( point[i] ) );
         }
         dummyImage->TransformIndexToPhysicalPoint( index, point );
         tempPointSet->SetPoint( j, point );
@@ -238,7 +238,7 @@ public:
         inputPointSet2->GetPoint(j, &point);
         for ( unsigned int i = 0; i < VDimension; i++ )
         {
-          index[i] = static_cast< IndexValueType >( vnl_math_rnd( point[i] ) );
+          index[i] = static_cast< IndexValueType >( vnl_math::rnd( point[i] ) );
         }
         dummyImage->TransformIndexToPhysicalPoint( index, point );
         tempPointSet->SetPoint(j, point);

--- a/src/deformationfieldgenerator/deformationfieldgenerator.h
+++ b/src/deformationfieldgenerator/deformationfieldgenerator.h
@@ -133,9 +133,9 @@ public:
     typename InputImageReaderType::Pointer reader2 = InputImageReaderType::New();
     typename IPPReaderType::Pointer ipp1Reader = IPPReaderType::New();
     typename IPPReaderType::Pointer ipp2Reader = IPPReaderType::New();
-    typename PointSetType::Pointer inputPointSet1 = 0;
-    typename PointSetType::Pointer inputPointSet2 = 0;
-    typename KernelTransformType::Pointer kernelTransform = 0;
+    typename PointSetType::Pointer inputPointSet1 = nullptr;
+    typename PointSetType::Pointer inputPointSet2 = nullptr;
+    typename KernelTransformType::Pointer kernelTransform = nullptr;
     typename DeformationFieldType::Pointer deformationField = DeformationFieldType::New();
     typename DeformationFieldWriterType::Pointer writer = DeformationFieldWriterType::New();
 

--- a/src/deformationfieldgenerator/itkMeshFileReaderBase.h
+++ b/src/deformationfieldgenerator/itkMeshFileReaderBase.h
@@ -19,7 +19,6 @@
 #define __itkMeshFileReaderBase_h_
 
 #include "itkMeshSource.h"
-#include "itkExceptionObject.h"
 
 namespace itk
 {

--- a/src/deformationfieldoperator/deformationfieldoperator.cxx
+++ b/src/deformationfieldoperator/deformationfieldoperator.cxx
@@ -113,7 +113,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/deformationfieldoperator/deformationfieldoperator.cxx
+++ b/src/deformationfieldoperator/deformationfieldoperator.cxx
@@ -113,7 +113,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/deformationfieldoperator/deformationfieldoperator.cxx
+++ b/src/deformationfieldoperator/deformationfieldoperator.cxx
@@ -112,7 +112,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-stop", stopValue );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/deformationfieldoperator/deformationfieldoperator.cxx
+++ b/src/deformationfieldoperator/deformationfieldoperator.cxx
@@ -112,7 +112,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-stop", stopValue );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/deformationfieldoperator/deformationfieldoperator.h
+++ b/src/deformationfieldoperator/deformationfieldoperator.h
@@ -21,7 +21,6 @@
 #include "ITKToolsBase.h"
 
 #include "itkImage.h"
-#include "itkExceptionObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkImageRegionIteratorWithIndex.h"

--- a/src/distancetransform/distancetransform.h
+++ b/src/distancetransform/distancetransform.h
@@ -21,7 +21,6 @@
 #include <string>
 
 #include "itkImage.h"
-#include "itkExceptionObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 

--- a/src/distancetransform/itkMorphSDTHelperImageFilter.h
+++ b/src/distancetransform/itkMorphSDTHelperImageFilter.h
@@ -37,12 +37,12 @@ public:
     if( C > 0)
       {
       // inside the mask
-      return static_cast<TOutput>(vcl_sqrt((double)A + this->m_Val));
+      return static_cast<TOutput>(std::sqrt((double)A + this->m_Val));
       }
     else
       {
       // outside the mask
-      return static_cast<TOutput>(- vcl_sqrt( this->m_Val -(double)B));
+      return static_cast<TOutput>(- std::sqrt( this->m_Val -(double)B));
       }
   }
 private:

--- a/src/enhancement/enhancement.cxx
+++ b/src/enhancement/enhancement.cxx
@@ -213,7 +213,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/enhancement/enhancement.cxx
+++ b/src/enhancement/enhancement.cxx
@@ -144,9 +144,9 @@ int main( int argc, char ** argv )
 
   bool retrescale = parser->ArgumentExists( "-rescaleoff" );
 
-  unsigned int maxThreads = itk::MultiThreader::GetGlobalDefaultNumberOfThreads();
+  unsigned int maxThreads = itk::MultiThreaderBase::GetGlobalDefaultNumberOfThreads();
   parser->GetCommandLineArgument( "-threads", maxThreads );
-  itk::MultiThreader::SetGlobalMaximumNumberOfThreads( maxThreads );
+  itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads( maxThreads );
 
   // Enhancement filter parameters
   double alpha = 0.5;

--- a/src/enhancement/enhancement.cxx
+++ b/src/enhancement/enhancement.cxx
@@ -231,7 +231,7 @@ int main( int argc, char ** argv )
   }
 
   /** Class that does the work. */
-  ITKToolsEnhancementBase * filter = NULL;
+  ITKToolsEnhancementBase * filter = nullptr;
 
   try
   {

--- a/src/enhancement/enhancement.cxx
+++ b/src/enhancement/enhancement.cxx
@@ -212,7 +212,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/enhancement/enhancement.cxx
+++ b/src/enhancement/enhancement.cxx
@@ -212,7 +212,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/enhancement/enhancement.cxx
+++ b/src/enhancement/enhancement.cxx
@@ -213,7 +213,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(
@@ -225,9 +225,9 @@ int main( int argc, char ** argv )
   if( !retNOCCheck ) return EXIT_FAILURE;
 
   /** Component type should be at least float. */
-  if ( componentType != itk::ImageIOBase::FLOAT && componentType != itk::ImageIOBase::DOUBLE )
+  if ( componentType != itk::IOComponentEnum::FLOAT && componentType != itk::IOComponentEnum::DOUBLE )
   {
-    componentType = itk::ImageIOBase::FLOAT;
+    componentType = itk::IOComponentEnum::FLOAT;
   }
 
   /** Class that does the work. */

--- a/src/enhancement/itkBinaryFunctorImageFilter2.hxx
+++ b/src/enhancement/itkBinaryFunctorImageFilter2.hxx
@@ -83,7 +83,7 @@ BinaryFunctorImageFilter2< TInputImage1, TInputImage2, TOutputImage >
   itkDebugMacro("Getting constant 1");
   const DecoratedInput1ImagePixelType *input = dynamic_cast< const DecoratedInput1ImagePixelType * >(
       this->ProcessObject::GetInput(0) );
-  if( input == NULL )
+  if( input == nullptr )
     {
     itkExceptionMacro(<<"Constant 1 is not set");
     }
@@ -139,7 +139,7 @@ BinaryFunctorImageFilter2< TInputImage1, TInputImage2, TOutputImage >
   itkDebugMacro("Getting constant 2");
   const DecoratedInput2ImagePixelType *input = dynamic_cast< const DecoratedInput2ImagePixelType * >(
       this->ProcessObject::GetInput(1) );
-  if( input == NULL )
+  if( input == nullptr )
     {
     itkExceptionMacro(<<"Constant 2 is not set");
     }
@@ -152,7 +152,7 @@ void
 BinaryFunctorImageFilter2< TInputImage1, TInputImage2, TOutputImage >
 ::GenerateOutputInformation()
 {
-  const DataObject * input = NULL;
+  const DataObject * input = nullptr;
   Input1ImagePointer inputPtr1 =
     dynamic_cast< const TInputImage1 * >( ProcessObject::GetInput(0) );
   Input2ImagePointer inputPtr2 =

--- a/src/enhancement/itkComparisonOperators.h
+++ b/src/enhancement/itkComparisonOperators.h
@@ -41,7 +41,7 @@ class AbsLessEqualCompare
 public:
   bool operator()( T a, T b )
   {
-    return vnl_math_abs( a ) <= vnl_math_abs( b );
+    return std::abs( a ) <= std::abs( b );
   }
 };
 
@@ -58,7 +58,7 @@ class AbsLessCompare
 public:
   bool operator()( T a, T b )
   {
-    return vnl_math_abs( a ) < vnl_math_abs( b );
+    return std::abs( a ) < std::abs( b );
   }
 };
 

--- a/src/enhancement/itkDescoteauxSheetnessFunctor.h
+++ b/src/enhancement/itkDescoteauxSheetnessFunctor.h
@@ -73,9 +73,9 @@ public:
       Functor::AbsLessCompare<EigenValueType>() );
 
     /** Take the absolute values and abbreviate. */
-    const RealType l1 = vnl_math_abs( sortedEigenValues[ 0 ] );
-    const RealType l2 = vnl_math_abs( sortedEigenValues[ 1 ] );
-    const RealType l3 = vnl_math_abs( sortedEigenValues[ 2 ] );
+    const RealType l1 = std::abs( sortedEigenValues[ 0 ] );
+    const RealType l2 = std::abs( sortedEigenValues[ 1 ] );
+    const RealType l3 = std::abs( sortedEigenValues[ 2 ] );
 
     /** Reject. */
     if( this->m_BrightObject )
@@ -103,7 +103,7 @@ public:
 
     /** Compute several structure measures. */
     const RealType Rsheet = l2 / l3;
-    const RealType Rblob  = vnl_math_abs( l3 + l3 - l2 - l1 ) / l3;
+    const RealType Rblob  = std::abs( l3 + l3 - l2 - l1 ) / l3;
     const RealType Rnoise = std::sqrt( l1 * l1 + l2 * l2 + l3 * l3 );
 
     /** Compute final sheetness measure, see Eq.(13). */

--- a/src/enhancement/itkDescoteauxSheetnessFunctor.h
+++ b/src/enhancement/itkDescoteauxSheetnessFunctor.h
@@ -108,9 +108,9 @@ public:
 
     /** Compute final sheetness measure, see Eq.(13). */
     RealType sheetness = NumericTraits<RealType>::Zero;
-    sheetness  =         vcl_exp( - ( Rsheet * Rsheet ) / ( 2.0 * this->m_Alpha * this->m_Alpha ) ); // sheetness vs lineness
-    sheetness *= ( 1.0 - vcl_exp( - ( Rblob  * Rblob )  / ( 2.0 * this->m_Beta * this->m_Beta ) ) ); // blobness
-    sheetness *= ( 1.0 - vcl_exp( - ( Rnoise * Rnoise ) / ( 2.0 * this->m_C * this->m_C ) ) );       // noise = structuredness
+    sheetness  =         std::exp( - ( Rsheet * Rsheet ) / ( 2.0 * this->m_Alpha * this->m_Alpha ) ); // sheetness vs lineness
+    sheetness *= ( 1.0 - std::exp( - ( Rblob  * Rblob )  / ( 2.0 * this->m_Beta * this->m_Beta ) ) ); // blobness
+    sheetness *= ( 1.0 - std::exp( - ( Rnoise * Rnoise ) / ( 2.0 * this->m_C * this->m_C ) ) );       // noise = structuredness
 
     return static_cast<TOutput>( sheetness );
   } // end operator ()

--- a/src/enhancement/itkDescoteauxSheetnessFunctor.h
+++ b/src/enhancement/itkDescoteauxSheetnessFunctor.h
@@ -104,7 +104,7 @@ public:
     /** Compute several structure measures. */
     const RealType Rsheet = l2 / l3;
     const RealType Rblob  = vnl_math_abs( l3 + l3 - l2 - l1 ) / l3;
-    const RealType Rnoise = vcl_sqrt( l1 * l1 + l2 * l2 + l3 * l3 );
+    const RealType Rnoise = std::sqrt( l1 * l1 + l2 * l2 + l3 * l3 );
 
     /** Compute final sheetness measure, see Eq.(13). */
     RealType sheetness = NumericTraits<RealType>::Zero;

--- a/src/enhancement/itkDescoteauxXiaoSheetnessFunctor.h
+++ b/src/enhancement/itkDescoteauxXiaoSheetnessFunctor.h
@@ -50,7 +50,7 @@ namespace Functor
  *
  * \par Reference
  * Multiscale Vessel Enhancement Filtering.
- * Medical Image Computing and Computer-Assisted Interventation MICCAI’98
+ * Medical Image Computing and Computer-Assisted Interventation MICCAI 98
  * Lecture Notes in Computer Science, 1998, Volume 1496/1998, 130-137,
  * DOI: 10.1007/BFb0056195
  *

--- a/src/enhancement/itkDescoteauxXiaoSheetnessFunctor.h
+++ b/src/enhancement/itkDescoteauxXiaoSheetnessFunctor.h
@@ -89,9 +89,9 @@ public:
       Functor::AbsLessCompare<EigenValueType>() );
 
     /** Take the absolute values and abbreviate. */
-    const RealType l1 = vnl_math_abs( sortedEigenValues[ 0 ] );
-    const RealType l2 = vnl_math_abs( sortedEigenValues[ 1 ] );
-    const RealType l3 = vnl_math_abs( sortedEigenValues[ 2 ] );
+    const RealType l1 = std::abs( sortedEigenValues[ 0 ] );
+    const RealType l2 = std::abs( sortedEigenValues[ 1 ] );
+    const RealType l3 = std::abs( sortedEigenValues[ 2 ] );
 
     const RealType gradientMagnitude = static_cast<RealType>( gMag ) ;
     const RealType eigenValuesSum = eigenValues[ 0 ]
@@ -121,7 +121,7 @@ public:
 
     /** Compute several structure measures. */
     const RealType Rsheet = l2 / l3;
-    const RealType Rblob  = vnl_math_abs( l3 + l3 - l2 - l1 ) / l3;
+    const RealType Rblob  = std::abs( l3 + l3 - l2 - l1 ) / l3;
     const RealType Rnoise = std::sqrt( l1 * l1 + l2 * l2 + l3 * l3 );
 
     /** Compute Descoteaux sheetness measure, see Eq. . */

--- a/src/enhancement/itkDescoteauxXiaoSheetnessFunctor.h
+++ b/src/enhancement/itkDescoteauxXiaoSheetnessFunctor.h
@@ -122,7 +122,7 @@ public:
     /** Compute several structure measures. */
     const RealType Rsheet = l2 / l3;
     const RealType Rblob  = vnl_math_abs( l3 + l3 - l2 - l1 ) / l3;
-    const RealType Rnoise = vcl_sqrt( l1 * l1 + l2 * l2 + l3 * l3 );
+    const RealType Rnoise = std::sqrt( l1 * l1 + l2 * l2 + l3 * l3 );
 
     /** Compute Descoteaux sheetness measure, see Eq. . */
     RealType sheetness = NumericTraits<RealType>::Zero;

--- a/src/enhancement/itkDescoteauxXiaoSheetnessFunctor.h
+++ b/src/enhancement/itkDescoteauxXiaoSheetnessFunctor.h
@@ -126,14 +126,14 @@ public:
 
     /** Compute Descoteaux sheetness measure, see Eq. . */
     RealType sheetness = NumericTraits<RealType>::Zero;
-    sheetness  =         vcl_exp( - ( Rsheet * Rsheet ) / ( 2.0 * this->m_Alpha * this->m_Alpha ) ); // sheetness vs lineness
-    sheetness *= ( 1.0 - vcl_exp( - ( Rblob  * Rblob )  / ( 2.0 * this->m_Beta * this->m_Beta ) ) ); // blobness
-    sheetness *= ( 1.0 - vcl_exp( - ( Rnoise * Rnoise ) / ( 2.0 * this->m_C * this->m_C ) ) );       // noise = structuredness
+    sheetness  =         std::exp( - ( Rsheet * Rsheet ) / ( 2.0 * this->m_Alpha * this->m_Alpha ) ); // sheetness vs lineness
+    sheetness *= ( 1.0 - std::exp( - ( Rblob  * Rblob )  / ( 2.0 * this->m_Beta * this->m_Beta ) ) ); // blobness
+    sheetness *= ( 1.0 - std::exp( - ( Rnoise * Rnoise ) / ( 2.0 * this->m_C * this->m_C ) ) );       // noise = structuredness
 
     // Step-edge suppressing proposed by Changyan Xiao
     // Dividing by Rnoise or l3 does not make much difference
-    //sheetness *= vcl_exp( -1.0 * m_Kappa * ( gradientMagnitude / Rnoise ) );
-    sheetness *= vcl_exp( -1.0 * m_Kappa * ( gradientMagnitude / l3 ) );
+    //sheetness *= std::exp( -1.0 * m_Kappa * ( gradientMagnitude / Rnoise ) );
+    sheetness *= std::exp( -1.0 * m_Kappa * ( gradientMagnitude / l3 ) );
 
     return static_cast<TOutput>( sheetness );
   } // end Evaluate()

--- a/src/enhancement/itkFrangiSheetnessFunctor.h
+++ b/src/enhancement/itkFrangiSheetnessFunctor.h
@@ -112,9 +112,9 @@ public:
 
     /** Compute Frangi sheetness measure. */
     RealType sheetness = NumericTraits<RealType>::Zero;
-    sheetness  =         vcl_exp( - ( Ra * Ra ) / ( 2.0 * m_Alpha * m_Alpha ) ); // sheetness vs lineness
-    sheetness *=         vcl_exp( - ( Rb * Rb ) / ( 2.0 * m_Beta * m_Beta ) );   // blobness
-    sheetness *= ( 1.0 - vcl_exp( - ( S  * S  ) / ( 2.0 * m_C * m_C ) ) );       // noise = structuredness
+    sheetness  =         std::exp( - ( Ra * Ra ) / ( 2.0 * m_Alpha * m_Alpha ) ); // sheetness vs lineness
+    sheetness *=         std::exp( - ( Rb * Rb ) / ( 2.0 * m_Beta * m_Beta ) );   // blobness
+    sheetness *= ( 1.0 - std::exp( - ( S  * S  ) / ( 2.0 * m_C * m_C ) ) );       // noise = structuredness
 
     return static_cast<TOutput>( sheetness );
   } // end operator ()

--- a/src/enhancement/itkFrangiSheetnessFunctor.h
+++ b/src/enhancement/itkFrangiSheetnessFunctor.h
@@ -107,8 +107,8 @@ public:
 
     /** Compute several structure measures. */
     const RealType Ra = l2 / l3;
-    const RealType Rb = l1 / vcl_sqrt( l2 * l3 );
-    const RealType S  = vcl_sqrt( l1 * l1 + l2 * l2 + l3 * l3 );
+    const RealType Rb = l1 / std::sqrt( l2 * l3 );
+    const RealType S  = std::sqrt( l1 * l1 + l2 * l2 + l3 * l3 );
 
     /** Compute Frangi sheetness measure. */
     RealType sheetness = NumericTraits<RealType>::Zero;

--- a/src/enhancement/itkFrangiSheetnessFunctor.h
+++ b/src/enhancement/itkFrangiSheetnessFunctor.h
@@ -37,7 +37,7 @@ namespace Functor
  *
  * \par Reference
  * Multiscale Vessel Enhancement Filtering.
- * Medical Image Computing and Computer-Assisted Interventation MICCAI’98
+ * Medical Image Computing and Computer-Assisted Interventation MICCAI 98
  * Lecture Notes in Computer Science, 1998, Volume 1496/1998, 130-137,
  * DOI: 10.1007/BFb0056195
  *

--- a/src/enhancement/itkFrangiSheetnessFunctor.h
+++ b/src/enhancement/itkFrangiSheetnessFunctor.h
@@ -76,9 +76,9 @@ public:
       Functor::AbsLessCompare<EigenValueType>() );
 
     /** Take the absolute values and abbreviate. */
-    const RealType l1 = vnl_math_abs( sortedEigenValues[ 0 ] );
-    const RealType l2 = vnl_math_abs( sortedEigenValues[ 1 ] );
-    const RealType l3 = vnl_math_abs( sortedEigenValues[ 2 ] );
+    const RealType l1 = std::abs( sortedEigenValues[ 0 ] );
+    const RealType l2 = std::abs( sortedEigenValues[ 1 ] );
+    const RealType l3 = std::abs( sortedEigenValues[ 2 ] );
 
     const RealType eigenValuesSum = eigenValues[ 0 ]
       + eigenValues[ 1 ] + eigenValues[ 2 ];

--- a/src/enhancement/itkFrangiSheetnessImageFilter.h
+++ b/src/enhancement/itkFrangiSheetnessImageFilter.h
@@ -35,7 +35,7 @@ namespace itk
  *
  * \par Reference
  * Multiscale Vessel Enhancement Filtering.
- * Medical Image Computing and Computer-Assisted Interventation MICCAI’98
+ * Medical Image Computing and Computer-Assisted Interventation MICCAI 98
  * Lecture Notes in Computer Science, 1998, Volume 1496/1998, 130-137,
  * DOI: 10.1007/BFb0056195
  *

--- a/src/enhancement/itkFrangiVesselnessFunctor.h
+++ b/src/enhancement/itkFrangiVesselnessFunctor.h
@@ -105,8 +105,8 @@ public:
 
     /** Compute several structure measures. */
     const RealType Ra = l2 / l3; // see Eq.(11)
-    const RealType Rb = l1 / vcl_sqrt( l2 * l3 ); // see Eq.(10)
-    const RealType S  = vcl_sqrt( l1 * l1 + l2 * l2 + l3 * l3 ); // see Eq.(12)
+    const RealType Rb = l1 / std::sqrt( l2 * l3 ); // see Eq.(10)
+    const RealType S  = std::sqrt( l1 * l1 + l2 * l2 + l3 * l3 ); // see Eq.(12)
 
     /** Compute final vesselness measure, see Eq.(13). */
     RealType vesselness = NumericTraits<RealType>::Zero;

--- a/src/enhancement/itkFrangiVesselnessFunctor.h
+++ b/src/enhancement/itkFrangiVesselnessFunctor.h
@@ -110,9 +110,9 @@ public:
 
     /** Compute final vesselness measure, see Eq.(13). */
     RealType vesselness = NumericTraits<RealType>::Zero;
-    vesselness  = ( 1.0 - vcl_exp( -( Ra * Ra ) / ( 2.0 * m_Alpha * m_Alpha ) ) ); // sheetness vs lineness
-    vesselness *=         vcl_exp( -( Rb * Rb ) / ( 2.0 * m_Beta  * m_Beta  ) );   // blobness
-    vesselness *= ( 1.0 - vcl_exp( -( S  * S )  / ( 2.0 * m_C     * m_C ) ) );     // noise = structuredness
+    vesselness  = ( 1.0 - std::exp( -( Ra * Ra ) / ( 2.0 * m_Alpha * m_Alpha ) ) ); // sheetness vs lineness
+    vesselness *=         std::exp( -( Rb * Rb ) / ( 2.0 * m_Beta  * m_Beta  ) );   // blobness
+    vesselness *= ( 1.0 - std::exp( -( S  * S )  / ( 2.0 * m_C     * m_C ) ) );     // noise = structuredness
 
     return static_cast<TOutput>( vesselness );
   } // end operator ()

--- a/src/enhancement/itkFrangiVesselnessFunctor.h
+++ b/src/enhancement/itkFrangiVesselnessFunctor.h
@@ -75,9 +75,9 @@ public:
       Functor::AbsLessCompare<EigenValueType>() );
 
     /** Take the absolute values and abbreviate. */
-    const RealType l1 = vnl_math_abs( sortedEigenValues[ 0 ] );
-    const RealType l2 = vnl_math_abs( sortedEigenValues[ 1 ] );
-    const RealType l3 = vnl_math_abs( sortedEigenValues[ 2 ] );
+    const RealType l1 = std::abs( sortedEigenValues[ 0 ] );
+    const RealType l2 = std::abs( sortedEigenValues[ 1 ] );
+    const RealType l3 = std::abs( sortedEigenValues[ 2 ] );
 
     /** Reject. */
     if( this->m_BrightObject )

--- a/src/enhancement/itkFrangiVesselnessFunctor.h
+++ b/src/enhancement/itkFrangiVesselnessFunctor.h
@@ -36,7 +36,7 @@ namespace Functor
  *
  * \par Reference
  * Multiscale Vessel Enhancement Filtering.
- * Medical Image Computing and Computer-Assisted Interventation MICCAI’98
+ * Medical Image Computing and Computer-Assisted Interventation MICCAI 98
  * Lecture Notes in Computer Science, 1998, Volume 1496/1998, 130-137,
  * DOI: 10.1007/BFb0056195
  *

--- a/src/enhancement/itkFrangiVesselnessImageFilter.h
+++ b/src/enhancement/itkFrangiVesselnessImageFilter.h
@@ -33,7 +33,7 @@ namespace itk
  *
  * \par Reference
  * Multiscale Vessel Enhancement Filtering.
- * Medical Image Computing and Computer-Assisted Interventation MICCAI’98
+ * Medical Image Computing and Computer-Assisted Interventation MICCAI 98
  * Lecture Notes in Computer Science, 1998, Volume 1496/1998, 130-137,
  * DOI: 10.1007/BFb0056195
  *

--- a/src/enhancement/itkFrangiXiaoSheetnessFunctor.h
+++ b/src/enhancement/itkFrangiXiaoSheetnessFunctor.h
@@ -50,7 +50,7 @@ namespace Functor
  *
  * \par Reference
  * Multiscale Vessel Enhancement Filtering.
- * Medical Image Computing and Computer-Assisted Interventation MICCAI’98
+ * Medical Image Computing and Computer-Assisted Interventation MICCAI 98
  * Lecture Notes in Computer Science, 1998, Volume 1496/1998, 130-137,
  * DOI: 10.1007/BFb0056195
  *

--- a/src/enhancement/itkFrangiXiaoSheetnessFunctor.h
+++ b/src/enhancement/itkFrangiXiaoSheetnessFunctor.h
@@ -89,9 +89,9 @@ public:
       Functor::AbsLessCompare<EigenValueType>() );
 
     /** Take the absolute values and abbreviate. */
-    const RealType l1 = vnl_math_abs( sortedEigenValues[ 0 ] );
-    const RealType l2 = vnl_math_abs( sortedEigenValues[ 1 ] );
-    const RealType l3 = vnl_math_abs( sortedEigenValues[ 2 ] );
+    const RealType l1 = std::abs( sortedEigenValues[ 0 ] );
+    const RealType l2 = std::abs( sortedEigenValues[ 1 ] );
+    const RealType l3 = std::abs( sortedEigenValues[ 2 ] );
 
     const RealType gradientMagnitude = static_cast<RealType>( gMag ) ;
     const RealType eigenValuesSum = eigenValues[ 0 ]

--- a/src/enhancement/itkFrangiXiaoSheetnessFunctor.h
+++ b/src/enhancement/itkFrangiXiaoSheetnessFunctor.h
@@ -121,8 +121,8 @@ public:
 
     /** Compute several structure measures. */
     const RealType Ra = l2 / l3; // see Eq.(11)
-    const RealType Rb = l1 / vcl_sqrt( l2 * l3 ); // see Eq.(10)
-    const RealType S  = vcl_sqrt( l1 * l1 + l2 * l2 + l3 * l3 ); // see Eq.(12)
+    const RealType Rb = l1 / std::sqrt( l2 * l3 ); // see Eq.(10)
+    const RealType S  = std::sqrt( l1 * l1 + l2 * l2 + l3 * l3 ); // see Eq.(12)
 
     /** Compute Frangi sheetness measure. */
     RealType sheetness = NumericTraits<RealType>::Zero;

--- a/src/enhancement/itkFrangiXiaoSheetnessFunctor.h
+++ b/src/enhancement/itkFrangiXiaoSheetnessFunctor.h
@@ -126,14 +126,14 @@ public:
 
     /** Compute Frangi sheetness measure. */
     RealType sheetness = NumericTraits<RealType>::Zero;
-    sheetness  =         vcl_exp( - ( Ra * Ra ) / ( 2.0 * m_Alpha * m_Alpha ) ); // sheetness vs lineness
-    sheetness *=         vcl_exp( - ( Rb * Rb ) / ( 2.0 * m_Beta * m_Beta ) );   // blobness
-    sheetness *= ( 1.0 - vcl_exp( - ( S  * S  ) / ( 2.0 * m_C * m_C ) ) );       // noise = structuredness
+    sheetness  =         std::exp( - ( Ra * Ra ) / ( 2.0 * m_Alpha * m_Alpha ) ); // sheetness vs lineness
+    sheetness *=         std::exp( - ( Rb * Rb ) / ( 2.0 * m_Beta * m_Beta ) );   // blobness
+    sheetness *= ( 1.0 - std::exp( - ( S  * S  ) / ( 2.0 * m_C * m_C ) ) );       // noise = structuredness
 
     // Step-edge suppressing proposed by Changyan Xiao
     // Dividing by S or l3 does not make much difference
-    //sheetness *= vcl_exp( -1.0 * m_Kappa * ( gradientMagnitude / S ) );
-    sheetness *= vcl_exp( -1.0 * m_Kappa * ( gradientMagnitude / l3 ) );
+    //sheetness *= std::exp( -1.0 * m_Kappa * ( gradientMagnitude / S ) );
+    sheetness *= std::exp( -1.0 * m_Kappa * ( gradientMagnitude / l3 ) );
 
     return static_cast<TOutput>( sheetness );
   } // end Evaluate()

--- a/src/enhancement/itkFrangiXiaoSheetnessImageFilter.h
+++ b/src/enhancement/itkFrangiXiaoSheetnessImageFilter.h
@@ -47,7 +47,7 @@ namespace itk
  *
  * \par Reference
  * Multiscale Vessel Enhancement Filtering.
- * Medical Image Computing and Computer-Assisted Interventation MICCAI’98
+ * Medical Image Computing and Computer-Assisted Interventation MICCAI 98
  * Lecture Notes in Computer Science, 1998, Volume 1496/1998, 130-137,
  * DOI: 10.1007/BFb0056195
  *

--- a/src/enhancement/itkGaussianEnhancementImageFilter.hxx
+++ b/src/enhancement/itkGaussianEnhancementImageFilter.hxx
@@ -31,8 +31,8 @@ template < typename TInPixel, typename TOutPixel >
 GaussianEnhancementImageFilter< TInPixel, TOutPixel >
 ::GaussianEnhancementImageFilter()
 {
-  this->m_UnaryFunctor = NULL;
-  this->m_BinaryFunctor = NULL;
+  this->m_UnaryFunctor = nullptr;
+  this->m_BinaryFunctor = nullptr;
   this->m_UnaryFunctorFilter = UnaryFunctorImageFilterType::New();//needed to be global?
   this->m_BinaryFunctorFilter = BinaryFunctorImageFilterType::New();
   this->m_Sigma = 1.0;
@@ -81,7 +81,7 @@ GaussianEnhancementImageFilter< TInPixel, TOutPixel >
     // Only one of them should be initialized
     this->m_UnaryFunctor = _arg;
     this->m_UnaryFunctorFilter->SetFunctor( _arg );
-    this->m_BinaryFunctor = NULL;
+    this->m_BinaryFunctor = nullptr;
     this->Modified();
   }
 } // end SetUnaryFunctor()
@@ -101,7 +101,7 @@ GaussianEnhancementImageFilter< TInPixel, TOutPixel >
     // Only one of them should be initialized
     this->m_BinaryFunctor = _arg;
     this->m_BinaryFunctorFilter->SetFunctor( _arg );
-    this->m_UnaryFunctor = NULL;
+    this->m_UnaryFunctor = nullptr;
     this->Modified();
   }
 } // end SetBinaryFunctor()

--- a/src/enhancement/itkGaussianEnhancementImageFilter.hxx
+++ b/src/enhancement/itkGaussianEnhancementImageFilter.hxx
@@ -132,7 +132,7 @@ GaussianEnhancementImageFilter< TInPixel, TOutPixel >
     this->m_BinaryFunctorFilter->SetNumberOfThreads( nt );
   }
 
-  if ( this->GetNumberOfThreads() != ( nt < 1 ? 1 : ( nt > ITK_MAX_THREADS ? ITK_MAX_THREADS : nt ) ) )
+  if ( this->GetNumberOfWorkUnits() != ( nt < 1 ? 1 : ( nt > ITK_MAX_THREADS ? ITK_MAX_THREADS : nt ) ) )
   {
     this->Modified();
   }

--- a/src/enhancement/itkGaussianEnhancementImageFilter.hxx
+++ b/src/enhancement/itkGaussianEnhancementImageFilter.hxx
@@ -51,7 +51,7 @@ GaussianEnhancementImageFilter< TInPixel, TOutPixel >
   this->m_SymmetricEigenValueFilter = EigenAnalysisFilterType::New();
   this->m_SymmetricEigenValueFilter->SetDimension( ImageDimension );
   this->m_SymmetricEigenValueFilter->OrderEigenValuesBy(
-    EigenAnalysisFilterType::FunctorType::OrderByValue );//OrderByMagnitude?
+    EigenValueOrderEnum::OrderByValue );//OrderByMagnitude?
 
   // Construct the rescale filter
   this->m_RescaleFilter = RescaleFilterType::New();

--- a/src/enhancement/itkModifiedKrissianVesselnessFunctor.h
+++ b/src/enhancement/itkModifiedKrissianVesselnessFunctor.h
@@ -72,9 +72,9 @@ public:
       Functor::AbsLessCompare<EigenValueType>() );
 
     /** Take the absolute values and abbreviate. */
-    const RealType l1 = vnl_math_abs( sortedEigenValues[ 0 ] );
-    const RealType l2 = vnl_math_abs( sortedEigenValues[ 1 ] );
-    const RealType l3 = vnl_math_abs( sortedEigenValues[ 2 ] );
+    const RealType l1 = std::abs( sortedEigenValues[ 0 ] );
+    const RealType l2 = std::abs( sortedEigenValues[ 1 ] );
+    const RealType l3 = std::abs( sortedEigenValues[ 2 ] );
 
     /** Reject. */
     if( this->m_BrightObject )

--- a/src/enhancement/itkMultiScaleGaussianEnhancementImageFilter.hxx
+++ b/src/enhancement/itkMultiScaleGaussianEnhancementImageFilter.hxx
@@ -296,9 +296,9 @@ MultiScaleGaussianEnhancementImageFilter< TInputImage, TOutputImage >
   case Self::LogarithmicSigmaSteps:
     {
       const double stepSize = std::max( 1e-10,
-        ( vcl_log( this->m_SigmaMaximum ) - vcl_log( this->m_SigmaMinimum ) )
+        ( std::log( this->m_SigmaMaximum ) - std::log( this->m_SigmaMinimum ) )
         / ( this->m_NumberOfSigmaSteps - 1 ) );
-      sigmaValue = vcl_exp( vcl_log ( this->m_SigmaMinimum ) + stepSize * scaleLevel );
+      sigmaValue = vcl_exp( std::log ( this->m_SigmaMinimum ) + stepSize * scaleLevel );
       break;
     }
   default:

--- a/src/enhancement/itkMultiScaleGaussianEnhancementImageFilter.hxx
+++ b/src/enhancement/itkMultiScaleGaussianEnhancementImageFilter.hxx
@@ -298,7 +298,7 @@ MultiScaleGaussianEnhancementImageFilter< TInputImage, TOutputImage >
       const double stepSize = std::max( 1e-10,
         ( std::log( this->m_SigmaMaximum ) - std::log( this->m_SigmaMinimum ) )
         / ( this->m_NumberOfSigmaSteps - 1 ) );
-      sigmaValue = vcl_exp( std::log ( this->m_SigmaMinimum ) + stepSize * scaleLevel );
+      sigmaValue = std::exp( std::log ( this->m_SigmaMinimum ) + stepSize * scaleLevel );
       break;
     }
   default:

--- a/src/enhancement/itkMultiScaleGaussianEnhancementImageFilter.hxx
+++ b/src/enhancement/itkMultiScaleGaussianEnhancementImageFilter.hxx
@@ -288,14 +288,14 @@ MultiScaleGaussianEnhancementImageFilter< TInputImage, TOutputImage >
   {
   case Self::EquispacedSigmaSteps:
     {
-      const double stepSize = vnl_math_max( 1e-10,
+      const double stepSize = std::max( 1e-10,
         ( this->m_SigmaMaximum - this->m_SigmaMinimum ) / ( this->m_NumberOfSigmaSteps - 1 ) );
       sigmaValue = this->m_SigmaMinimum + stepSize * scaleLevel;
       break;
     }
   case Self::LogarithmicSigmaSteps:
     {
-      const double stepSize = vnl_math_max( 1e-10,
+      const double stepSize = std::max( 1e-10,
         ( vcl_log( this->m_SigmaMaximum ) - vcl_log( this->m_SigmaMinimum ) )
         / ( this->m_NumberOfSigmaSteps - 1 ) );
       sigmaValue = vcl_exp( vcl_log ( this->m_SigmaMinimum ) + stepSize * scaleLevel );

--- a/src/enhancement/itkMultiScaleGaussianEnhancementImageFilter.hxx
+++ b/src/enhancement/itkMultiScaleGaussianEnhancementImageFilter.hxx
@@ -265,7 +265,7 @@ MultiScaleGaussianEnhancementImageFilter< TInputImage, TOutputImage >
   typename MaxFilterType::Pointer maxFilter = MaxFilterType::New();
   maxFilter->SetInput1( this->GetOutput() );
   maxFilter->SetInput2( seOutput );
-  maxFilter->SetNumberOfThreads(this->GetNumberOfThreads());
+  maxFilter->SetNumberOfThreads(this->GetNumberOfWorkUnits());
   maxFilter->InPlaceOn();
   maxFilter->Update();
   this->GraftOutput( maxFilter->GetOutput() );

--- a/src/enhancement/itkMultiScaleGaussianEnhancementImageFilter.hxx
+++ b/src/enhancement/itkMultiScaleGaussianEnhancementImageFilter.hxx
@@ -265,7 +265,7 @@ MultiScaleGaussianEnhancementImageFilter< TInputImage, TOutputImage >
   typename MaxFilterType::Pointer maxFilter = MaxFilterType::New();
   maxFilter->SetInput1( this->GetOutput() );
   maxFilter->SetInput2( seOutput );
-  maxFilter->SetNumberOfThreads(this->GetNumberOfWorkUnits());
+  maxFilter->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
   maxFilter->InPlaceOn();
   maxFilter->Update();
   this->GraftOutput( maxFilter->GetOutput() );

--- a/src/enhancement/itkStrainEnergySheetnessFunctor.h
+++ b/src/enhancement/itkStrainEnergySheetnessFunctor.h
@@ -109,13 +109,13 @@ public:
       const RealType HI2 = 3.0 * vnl_math_sqr( mLamda );
 
       // Compute the strain energy function, see Eq.(18)
-      const RealType SE = vcl_sqrt( ( 1.0 - 2.0 * this->m_Nu ) * HI2
+      const RealType SE = std::sqrt( ( 1.0 - 2.0 * this->m_Nu ) * HI2
         + ( 1.0 + this->m_Nu ) * HA2 );
 
       // Compute the FA, see Eq.(26)
       RealType FA2 = NumericTraits<RealType>::Zero;
       FA2 = HA2 / H2;
-      const RealType FA = vcl_sqrt( 3.0 * FA2 );
+      const RealType FA = std::sqrt( 3.0 * FA2 );
 
       // Calculate the mode, see Eq.(27)
       RealType tm1 = NumericTraits<RealType>::Zero;
@@ -127,7 +127,7 @@ public:
       }
       tm1 /= Dimension;
       tm2 = vcl_pow( tm2 / 3.0, 1.5 );
-      RealType mode = vcl_sqrt( 2.0 ) * tm1 / tm2;
+      RealType mode = std::sqrt( 2.0 ) * tm1 / tm2;
 
       // Combine FA and mode to generate the S(x), see Eq.(28)
       // Needs work

--- a/src/enhancement/itkStrainEnergySheetnessFunctor.h
+++ b/src/enhancement/itkStrainEnergySheetnessFunctor.h
@@ -122,11 +122,11 @@ public:
       RealType tm2 = NumericTraits<RealType>::Zero;
       for ( unsigned int i = 0; i < Dimension; ++i )
       {
-        tm1 += vcl_pow( eigenValues[ i ] - mLamda, Dimension );
+        tm1 += std::pow( eigenValues[ i ] - mLamda, Dimension );
         tm2 += vnl_math_sqr( eigenValues[ i ] - mLamda );
       }
       tm1 /= Dimension;
-      tm2 = vcl_pow( tm2 / 3.0, 1.5 );
+      tm2 = std::pow( tm2 / 3.0, 1.5 );
       RealType mode = std::sqrt( 2.0 ) * tm1 / tm2;
 
       // Combine FA and mode to generate the S(x), see Eq.(28)
@@ -134,7 +134,7 @@ public:
       if ( FA > NumericTraits<RealType>::One )
       {
         RealType p2 = this->m_Kappa;
-        SES = vcl_pow( ( 1.0 - mode ) / 2.0, p2 );
+        SES = std::pow( ( 1.0 - mode ) / 2.0, p2 );
       }
       else
       {

--- a/src/enhancement/itkStrainEnergySheetnessFunctor.h
+++ b/src/enhancement/itkStrainEnergySheetnessFunctor.h
@@ -83,7 +83,7 @@ public:
     for ( unsigned int i = 0; i < Dimension; ++i )
     {
       RealType tmp1 = eigenValues[ i ];
-      RealType tmp2 = vnl_math_abs( tmp1 );
+      RealType tmp2 = std::abs( tmp1 );
       if ( maxEvMag < tmp2 )
       {
         maxEvMag = tmp2;

--- a/src/enhancement/itkStrainEnergySheetnessFunctor.h
+++ b/src/enhancement/itkStrainEnergySheetnessFunctor.h
@@ -102,11 +102,11 @@ public:
       RealType HA2 = NumericTraits<RealType>::Zero;
       for ( unsigned int i = 0; i < Dimension; ++i )
       {
-        H2 += vnl_math_sqr( eigenValues[ i ] );
-        HA2 += vnl_math_sqr( eigenValues[ i ] - mLamda );
+        H2 += vnl_math::sqr( eigenValues[ i ] );
+        HA2 += vnl_math::sqr( eigenValues[ i ] - mLamda );
       }
 
-      const RealType HI2 = 3.0 * vnl_math_sqr( mLamda );
+      const RealType HI2 = 3.0 * vnl_math::sqr( mLamda );
 
       // Compute the strain energy function, see Eq.(18)
       const RealType SE = std::sqrt( ( 1.0 - 2.0 * this->m_Nu ) * HI2
@@ -123,7 +123,7 @@ public:
       for ( unsigned int i = 0; i < Dimension; ++i )
       {
         tm1 += std::pow( eigenValues[ i ] - mLamda, Dimension );
-        tm2 += vnl_math_sqr( eigenValues[ i ] - mLamda );
+        tm2 += vnl_math::sqr( eigenValues[ i ] - mLamda );
       }
       tm1 /= Dimension;
       tm2 = std::pow( tm2 / 3.0, 1.5 );

--- a/src/enhancement/itkStrainEnergySheetnessFunctor.h
+++ b/src/enhancement/itkStrainEnergySheetnessFunctor.h
@@ -142,7 +142,7 @@ public:
       }
 
       // Relative Hessian strength, see Eq.(25)
-      const RealType edgeW = vcl_exp( -this->m_Beta * gMag / maxEvMag );
+      const RealType edgeW = std::exp( -this->m_Beta * gMag / maxEvMag );
 
       // Integrate the above terms to form the final sheet-tuned strain energy density, see Eq.(29)
       SES *= edgeW * SE;

--- a/src/enhancement/itkStrainEnergyVesselnessFunctor.h
+++ b/src/enhancement/itkStrainEnergyVesselnessFunctor.h
@@ -91,7 +91,7 @@ public:
     for ( unsigned int i = 0; i < Dimension; ++i )
     {
       RealType tmp1 = eigenValues[ i ];
-      RealType tmp2 = vnl_math_abs( tmp1 );
+      RealType tmp2 = std::abs( tmp1 );
       if ( maxEvMag < tmp2 )
       {
         maxEvMag = tmp2;

--- a/src/enhancement/itkStrainEnergyVesselnessFunctor.h
+++ b/src/enhancement/itkStrainEnergyVesselnessFunctor.h
@@ -121,11 +121,11 @@ public:
       RealType HA2 = NumericTraits<RealType>::Zero;
       for ( unsigned int i = 0; i < Dimension; ++i )
       {
-        H2 += vnl_math_sqr( eigenValues[ i ] );
-        HA2 += vnl_math_sqr( eigenValues[ i ] - mLamda );
+        H2 += vnl_math::sqr( eigenValues[ i ] );
+        HA2 += vnl_math::sqr( eigenValues[ i ] - mLamda );
       }
 
-      const RealType HI2 = 3.0 * vnl_math_sqr( mLamda );
+      const RealType HI2 = 3.0 * vnl_math::sqr( mLamda );
 
       // Compute the strain energy density, see Eq.(20)
       const RealType SE = std::sqrt( ( 1.0 - 2.0 * this->m_Nu ) * HI2
@@ -142,7 +142,7 @@ public:
       for ( unsigned int i = 0; i < Dimension; ++i )
       {
         tm1 += std::pow( eigenValues[ i ] - mLamda, Dimension );
-        tm2 += vnl_math_sqr( eigenValues[ i ] - mLamda );
+        tm2 += vnl_math::sqr( eigenValues[ i ] - mLamda );
       }
       tm1 /= Dimension;
       tm2 = std::pow( tm2 / 3.0, 1.5 );

--- a/src/enhancement/itkStrainEnergyVesselnessFunctor.h
+++ b/src/enhancement/itkStrainEnergyVesselnessFunctor.h
@@ -160,7 +160,7 @@ public:
       }
 
       // Relative Hessian strength function, see Eq.(27)
-      const RealType edgeW = vcl_exp( -this->m_Beta * gradientMagnitude / maxEvMag );
+      const RealType edgeW = std::exp( -this->m_Beta * gradientMagnitude / maxEvMag );
 
       // Integrate the above terms to form the final vessel-tuned strain energy density, see Eq.(31)
       SEV *= edgeW * SE;

--- a/src/enhancement/itkStrainEnergyVesselnessFunctor.h
+++ b/src/enhancement/itkStrainEnergyVesselnessFunctor.h
@@ -128,13 +128,13 @@ public:
       const RealType HI2 = 3.0 * vnl_math_sqr( mLamda );
 
       // Compute the strain energy density, see Eq.(20)
-      const RealType SE = vcl_sqrt( ( 1.0 - 2.0 * this->m_Nu ) * HI2
+      const RealType SE = std::sqrt( ( 1.0 - 2.0 * this->m_Nu ) * HI2
         + ( 1.0 + this->m_Nu ) * HA2 );
 
       // Compute the FA, see Eq.(28)
       RealType FA2 = NumericTraits<RealType>::Zero;
       FA2 = HA2 / H2;
-      const RealType FA = vcl_sqrt( 3.0 * FA2 );
+      const RealType FA = std::sqrt( 3.0 * FA2 );
 
       // Calculate the mode(x), see Eq.(29)
       RealType tm1 = NumericTraits<RealType>::Zero;
@@ -146,7 +146,7 @@ public:
       }
       tm1 /= Dimension;
       tm2 = vcl_pow( tm2 / 3.0, 1.5 );
-      const RealType mode = vcl_sqrt( 2.0 ) * tm1 / tm2;
+      const RealType mode = std::sqrt( 2.0 ) * tm1 / tm2;
 
       // Combine FA and mode to generate the pow(V(x),k), see Eq.(30)
       if ( FA > NumericTraits<RealType>::One )

--- a/src/enhancement/itkStrainEnergyVesselnessFunctor.h
+++ b/src/enhancement/itkStrainEnergyVesselnessFunctor.h
@@ -141,22 +141,22 @@ public:
       RealType tm2 = NumericTraits<RealType>::Zero;
       for ( unsigned int i = 0; i < Dimension; ++i )
       {
-        tm1 += vcl_pow( eigenValues[ i ] - mLamda, Dimension );
+        tm1 += std::pow( eigenValues[ i ] - mLamda, Dimension );
         tm2 += vnl_math_sqr( eigenValues[ i ] - mLamda );
       }
       tm1 /= Dimension;
-      tm2 = vcl_pow( tm2 / 3.0, 1.5 );
+      tm2 = std::pow( tm2 / 3.0, 1.5 );
       const RealType mode = std::sqrt( 2.0 ) * tm1 / tm2;
 
       // Combine FA and mode to generate the pow(V(x),k), see Eq.(30)
       if ( FA > NumericTraits<RealType>::One )
       {
-        SEV = vcl_pow( ( mode + 1.0 ) / 2.0, this->m_Kappa );
+        SEV = std::pow( ( mode + 1.0 ) / 2.0, this->m_Kappa );
       }
       else
       {
         RealType p1 = 0.5 * this->m_Kappa;
-        SEV = vcl_pow( FA, p1 );
+        SEV = std::pow( FA, p1 );
       }
 
       // Relative Hessian strength function, see Eq.(27)

--- a/src/extracteveryotherslice/extracteveryotherslice.cxx
+++ b/src/extracteveryotherslice/extracteveryotherslice.cxx
@@ -99,7 +99,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/extracteveryotherslice/extracteveryotherslice.cxx
+++ b/src/extracteveryotherslice/extracteveryotherslice.cxx
@@ -100,7 +100,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/extracteveryotherslice/extracteveryotherslice.cxx
+++ b/src/extracteveryotherslice/extracteveryotherslice.cxx
@@ -99,7 +99,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/extracteveryotherslice/extracteveryotherslice.cxx
+++ b/src/extracteveryotherslice/extracteveryotherslice.cxx
@@ -127,7 +127,7 @@ int main( int argc, char **argv )
   }
 
   /** Class that does the work. */
-  ITKToolsExtractEveryOtherSliceBase * filter = NULL;
+  ITKToolsExtractEveryOtherSliceBase * filter = nullptr;
 
   try
   {

--- a/src/extracteveryotherslice/extracteveryotherslice.cxx
+++ b/src/extracteveryotherslice/extracteveryotherslice.cxx
@@ -100,7 +100,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/extracteveryotherslice/extracteveryotherslice.h
+++ b/src/extracteveryotherslice/extracteveryotherslice.h
@@ -97,7 +97,7 @@ public:
     /** Define size of output image. */
     SizeType sizeIn = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
     SizeType sizeOut = sizeIn;
-    float newSize = vcl_ceil(
+    float newSize = std::ceil(
       ( static_cast<float>( sizeOut[ this->m_Direction ] - this->m_Offset ) )
       / static_cast<float>( this->m_EveryOther ) );
     sizeOut[ this->m_Direction ] = static_cast<unsigned int>( newSize );

--- a/src/extractindexfromvectorimage/extractindexfromvectorimage.cxx
+++ b/src/extractindexfromvectorimage/extractindexfromvectorimage.cxx
@@ -85,7 +85,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/extractindexfromvectorimage/extractindexfromvectorimage.cxx
+++ b/src/extractindexfromvectorimage/extractindexfromvectorimage.cxx
@@ -85,7 +85,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/extractindexfromvectorimage/extractindexfromvectorimage.cxx
+++ b/src/extractindexfromvectorimage/extractindexfromvectorimage.cxx
@@ -84,7 +84,7 @@ int main( int argc, char ** argv )
   parser->GetCommandLineArgument( "-ind", indices );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/extractindexfromvectorimage/extractindexfromvectorimage.cxx
+++ b/src/extractindexfromvectorimage/extractindexfromvectorimage.cxx
@@ -84,7 +84,7 @@ int main( int argc, char ** argv )
   parser->GetCommandLineArgument( "-ind", indices );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/extractslice/extractslice.cxx
+++ b/src/extractslice/extractslice.cxx
@@ -96,7 +96,7 @@ int main( int argc, char ** argv )
   bool useCompression = parser->ArgumentExists( "-z" );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/extractslice/extractslice.cxx
+++ b/src/extractslice/extractslice.cxx
@@ -97,7 +97,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   std::vector<unsigned int> imageSize;

--- a/src/extractslice/extractslice.cxx
+++ b/src/extractslice/extractslice.cxx
@@ -97,7 +97,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   std::vector<unsigned int> imageSize;

--- a/src/extractslice/extractslice.cxx
+++ b/src/extractslice/extractslice.cxx
@@ -96,7 +96,7 @@ int main( int argc, char ** argv )
   bool useCompression = parser->ArgumentExists( "-z" );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/gaussianimagefilter/gaussianimagefilter.cxx
+++ b/src/gaussianimagefilter/gaussianimagefilter.cxx
@@ -134,7 +134,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/gaussianimagefilter/gaussianimagefilter.cxx
+++ b/src/gaussianimagefilter/gaussianimagefilter.cxx
@@ -133,7 +133,7 @@ int main( int argc, char ** argv )
   else whichOperation = "Gaussian";
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/gaussianimagefilter/gaussianimagefilter.cxx
+++ b/src/gaussianimagefilter/gaussianimagefilter.cxx
@@ -171,7 +171,7 @@ int main( int argc, char ** argv )
   }
 
   /** Class that does the work. */
-  ITKToolsGaussianBase * filter = NULL;
+  ITKToolsGaussianBase * filter = nullptr;
 
   try
   {

--- a/src/gaussianimagefilter/gaussianimagefilter.cxx
+++ b/src/gaussianimagefilter/gaussianimagefilter.cxx
@@ -134,7 +134,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/gaussianimagefilter/gaussianimagefilter.cxx
+++ b/src/gaussianimagefilter/gaussianimagefilter.cxx
@@ -133,7 +133,7 @@ int main( int argc, char ** argv )
   else whichOperation = "Gaussian";
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/gaussianimagefilter/itkHessianRecursiveGaussianImageFilter2.txx
+++ b/src/gaussianimagefilter/itkHessianRecursiveGaussianImageFilter2.txx
@@ -66,10 +66,10 @@ HessianRecursiveGaussianImageFilter2<TInputImage,TOutputImage>
   this->m_DerivativeFilterA = DerivativeFilterAType::New();
   this->m_DerivativeFilterB = DerivativeFilterBType::New();
 
-  this->m_DerivativeFilterA->SetOrder( DerivativeFilterAType::FirstOrder );
+  this->m_DerivativeFilterA->SetOrder( GaussianOrderEnum::FirstOrder );
   this->m_DerivativeFilterA->SetNormalizeAcrossScale( this->m_NormalizeAcrossScale );
 
-  this->m_DerivativeFilterB->SetOrder( DerivativeFilterBType::FirstOrder );
+  this->m_DerivativeFilterB->SetOrder( GaussianOrderEnum::FirstOrder );
   this->m_DerivativeFilterB->SetNormalizeAcrossScale( this->m_NormalizeAcrossScale );
 
   this->m_DerivativeFilterA->SetInput( this->GetInput() );
@@ -249,8 +249,8 @@ HessianRecursiveGaussianImageFilter2<TInputImage,TOutputImage >
       // to smooth one of the other directions.
       if( dimb == dima )
       {
-        this->m_DerivativeFilterA->SetOrder( DerivativeFilterAType::SecondOrder );
-        this->m_DerivativeFilterB->SetOrder( DerivativeFilterBType::ZeroOrder );
+        this->m_DerivativeFilterA->SetOrder( GaussianOrderEnum::SecondOrder );
+        this->m_DerivativeFilterB->SetOrder( GaussianOrderEnum::ZeroOrder );
 
         unsigned int i = 0;
         unsigned int j = 0;
@@ -285,8 +285,8 @@ HessianRecursiveGaussianImageFilter2<TInputImage,TOutputImage >
       }
       else
       {
-        this->m_DerivativeFilterA->SetOrder( DerivativeFilterAType::FirstOrder );
-        this->m_DerivativeFilterB->SetOrder( DerivativeFilterBType::FirstOrder );
+        this->m_DerivativeFilterA->SetOrder( GaussianOrderEnum::FirstOrder );
+        this->m_DerivativeFilterB->SetOrder( GaussianOrderEnum::FirstOrder );
 
         unsigned int i = 0;
         unsigned int j = 0;

--- a/src/gaussianimagefilter/itkHessianRecursiveGaussianImageFilter2.txx
+++ b/src/gaussianimagefilter/itkHessianRecursiveGaussianImageFilter2.txx
@@ -324,8 +324,6 @@ HessianRecursiveGaussianImageFilter2<TInputImage,TOutputImage >
         derivativeImage = this->m_DerivativeFilterB->GetOutput();
       }
 
-      progress->ResetFilterProgressAndKeepAccumulatedProgress();
-
       // Copy the results to the corresponding component
       // on the output image of vectors
       this->m_ImageAdaptor->SelectNthElement( element++ );

--- a/src/gaussianimagefilter/itkHessianRecursiveGaussianImageFilter2.txx
+++ b/src/gaussianimagefilter/itkHessianRecursiveGaussianImageFilter2.txx
@@ -56,7 +56,7 @@ HessianRecursiveGaussianImageFilter2<TInputImage,TOutputImage>
   for( unsigned int i = 0; i < NumberOfSmoothingFilters; i++ )
   {
     GaussianFilterPointer filter = GaussianFilterType::New();
-    filter->SetOrder( GaussianFilterType::ZeroOrder );
+    filter->SetOrder( GaussianOrderEnum::ZeroOrder );
     filter->SetNormalizeAcrossScale( this->m_NormalizeAcrossScale );
     filter->ReleaseDataFlagOn();
     this->m_SmoothingFilters.push_back( filter );

--- a/src/gaussianimagefilter/itkSmoothingRecursiveGaussianImageFilter2.h
+++ b/src/gaussianimagefilter/itkSmoothingRecursiveGaussianImageFilter2.h
@@ -131,7 +131,6 @@ public:
       \li FirstOrder is equivalent to convolving with the first derivative of a Gaussian.
       \li SecondOrder is equivalent to convolving with the second derivative of a Gaussian.
     */
-  typedef typename InternalGaussianFilterType::OrderEnumType OrderEnumType;
   typedef FixedArray< unsigned int,
     itkGetStaticConstMacro(ImageDimension) >              OrderType;
   virtual void SetOrder( const unsigned int order );

--- a/src/gaussianimagefilter/itkSmoothingRecursiveGaussianImageFilter2.txx
+++ b/src/gaussianimagefilter/itkSmoothingRecursiveGaussianImageFilter2.txx
@@ -63,7 +63,7 @@ SmoothingRecursiveGaussianImageFilter2<TInputImage,TOutputImage>
   for( unsigned int i = 0; i < ImageDimension - 1; i++ )
   {
     this->m_SmoothingFilters[ i ] = InternalGaussianFilterType::New();
-    this->m_SmoothingFilters[ i ]->SetOrder( InternalGaussianFilterType::ZeroOrder );
+    this->m_SmoothingFilters[ i ]->SetOrder( GaussianOrderEnum::ZeroOrder );
     this->m_SmoothingFilters[ i ]->SetNormalizeAcrossScale( this->m_NormalizeAcrossScale );
     this->m_SmoothingFilters[ i ]->SetDirection( i + 1 );
     this->m_SmoothingFilters[ i ]->ReleaseDataFlagOn();
@@ -198,15 +198,15 @@ SmoothingRecursiveGaussianImageFilter2<TInputImage,TOutputImage>
     {
       if( order[ i + 1 ] == 0 )
       {
-        this->m_SmoothingFilters[ i ]->SetOrder( InternalGaussianFilterType::ZeroOrder );
+        this->m_SmoothingFilters[ i ]->SetOrder( GaussianOrderEnum::ZeroOrder );
       }
       else if( order[ i + 1 ] == 1 )
       {
-        this->m_SmoothingFilters[ i ]->SetOrder( InternalGaussianFilterType::FirstOrder );
+        this->m_SmoothingFilters[ i ]->SetOrder( GaussianOrderEnum::FirstOrder );
       }
       else if( order[ i + 1 ] == 2 )
       {
-        this->m_SmoothingFilters[ i ]->SetOrder( InternalGaussianFilterType::SecondOrder );
+        this->m_SmoothingFilters[ i ]->SetOrder( GaussianOrderEnum::SecondOrder );
       }
       //else warning??
     } // end for

--- a/src/gaussianimagefilter/itkSmoothingRecursiveGaussianImageFilter2.txx
+++ b/src/gaussianimagefilter/itkSmoothingRecursiveGaussianImageFilter2.txx
@@ -54,7 +54,7 @@ SmoothingRecursiveGaussianImageFilter2<TInputImage,TOutputImage>
 
   /** Setup the first smoothing filter. */
   this->m_FirstSmoothingFilter = FirstGaussianFilterType::New();
-  this->m_FirstSmoothingFilter->SetOrder( FirstGaussianFilterType::ZeroOrder );
+  this->m_FirstSmoothingFilter->SetOrder( GaussianOrderEnum::ZeroOrder );
   this->m_FirstSmoothingFilter->SetDirection( 0 );
   this->m_FirstSmoothingFilter->SetNormalizeAcrossScale( this->m_NormalizeAcrossScale );
   this->m_FirstSmoothingFilter->ReleaseDataFlagOn();
@@ -181,15 +181,15 @@ SmoothingRecursiveGaussianImageFilter2<TInputImage,TOutputImage>
     /** Set the order for the first smoothing filter. */
     if( order[ 0 ] == 0 )
     {
-      this->m_FirstSmoothingFilter->SetOrder( FirstGaussianFilterType::ZeroOrder );
+      this->m_FirstSmoothingFilter->SetOrder( GaussianOrderEnum::ZeroOrder );
     }
     else if( order[ 0 ] == 1 )
     {
-      this->m_FirstSmoothingFilter->SetOrder( FirstGaussianFilterType::FirstOrder );
+      this->m_FirstSmoothingFilter->SetOrder( GaussianOrderEnum::FirstOrder );
     }
     else if( order[ 0 ] == 2 )
     {
-      this->m_FirstSmoothingFilter->SetOrder( FirstGaussianFilterType::SecondOrder );
+      this->m_FirstSmoothingFilter->SetOrder( GaussianOrderEnum::SecondOrder );
     }
     //else warning??
 

--- a/src/getdicominformation/getdicominformation.cxx
+++ b/src/getdicominformation/getdicominformation.cxx
@@ -187,18 +187,27 @@ int main( int argc, char **argv )
 
   /** Get patient information from the dicomIO. */
   const unsigned int maxSize = 255;
+
+  const auto getDicomValue = [gdcmIO](const char(&dicomTag)[sizeof("0123|0123")], char(&dicomValue)[maxSize])
+  {
+    std::string str;
+    itk::ExposeMetaData(gdcmIO->GetMetaDataDictionary(), dicomTag, str);
+    std::strncpy(dicomValue, str.c_str(), sizeof(dicomValue));
+    dicomValue[sizeof(dicomValue) - 1] = '\0';
+  };
+
   char patientName[maxSize];
-  gdcmIO->GetPatientName( patientName );
+  getDicomValue("0010|0010", patientName);
   char patientAge[maxSize];
-  gdcmIO->GetPatientAge( patientAge );
+  getDicomValue("0010|1010", patientAge);
   char patientSex[maxSize];
-  gdcmIO->GetPatientSex( patientSex );
+  getDicomValue("0010|0040", patientSex);
   char patientDOB[maxSize];
-  gdcmIO->GetPatientDOB( patientDOB );
+  getDicomValue("0010|0030", patientDOB);
   char patientID[maxSize];
-  gdcmIO->GetPatientID( patientID );
+  getDicomValue("0010|0020", patientID);
   char bodypart[maxSize];
-  gdcmIO->GetBodyPart( bodypart );
+  getDicomValue("0018|0015", bodypart);
   std::string position = "";
   gdcmIO->GetValueFromTag( "0018|5100", position );
   std::string viewPosition = "";
@@ -216,17 +225,17 @@ int main( int argc, char **argv )
 
   /** Get study information from the dicomIO. */
   char noSeries[maxSize];
-  gdcmIO->GetNumberOfSeriesInStudy( noSeries );
+  getDicomValue("0020|1000", noSeries);
   char noRelatedSeries[maxSize];
-  gdcmIO->GetNumberOfStudyRelatedSeries( noRelatedSeries );
+  getDicomValue("0020|1206", noRelatedSeries);
   std::string studyDate = "";
   gdcmIO->GetValueFromTag( "0008|0020", studyDate );
   std::string studyTime = "";
   gdcmIO->GetValueFromTag( "0008|0030", studyTime );
   char studyDesc[maxSize];
-  gdcmIO->GetStudyDescription( studyDesc );
+  getDicomValue("0008|1030", studyDesc);
   char studyID[maxSize];
-  gdcmIO->GetStudyID( studyID );
+  getDicomValue("0020|0010", studyID);
   std::string protocolName = "";
   gdcmIO->GetValueFromTag( "0018|1030", protocolName );
 
@@ -256,15 +265,15 @@ int main( int argc, char **argv )
 
   /** Get scanner information from the dicomIO. */
   char modality[maxSize];
-  gdcmIO->GetModality( modality );
+  getDicomValue("0008|0060", modality);
   char manufacturer[maxSize];
-  gdcmIO->GetManufacturer( manufacturer );
+  getDicomValue("0008|0070", manufacturer);
   char model[maxSize];
-  gdcmIO->GetModel( model );
+  getDicomValue("0008|1090", model);
   char scanOptions[maxSize];
-  gdcmIO->GetScanOptions( scanOptions );
+  getDicomValue("0018|0022", scanOptions);
   char institution[maxSize];
-  gdcmIO->GetInstitution( institution );
+  getDicomValue("0008|0080", institution);
   std::string convolutionKernel = "";
   gdcmIO->GetValueFromTag( "0018|1210", convolutionKernel );
 

--- a/src/histogramequalizeimage/histogramequalizeimage.cxx
+++ b/src/histogramequalizeimage/histogramequalizeimage.cxx
@@ -87,7 +87,7 @@ int main( int argc, char** argv )
   parser->GetCommandLineArgument( "-mask", maskFileName );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/histogramequalizeimage/histogramequalizeimage.cxx
+++ b/src/histogramequalizeimage/histogramequalizeimage.cxx
@@ -87,7 +87,7 @@ int main( int argc, char** argv )
   parser->GetCommandLineArgument( "-mask", maskFileName );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/histogramequalizeimage/histogramequalizeimage.cxx
+++ b/src/histogramequalizeimage/histogramequalizeimage.cxx
@@ -100,7 +100,7 @@ int main( int argc, char** argv )
   if( !retNOCCheck ) return EXIT_FAILURE;
 
   /** Class that does the work. */
-  ITKToolsHistogramEqualizeImageBase * filter = NULL;
+  ITKToolsHistogramEqualizeImageBase * filter = nullptr;
 
   try
   {

--- a/src/histogramequalizeimage/histogramequalizeimage.cxx
+++ b/src/histogramequalizeimage/histogramequalizeimage.cxx
@@ -88,7 +88,7 @@ int main( int argc, char** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/histogramequalizeimage/histogramequalizeimage.cxx
+++ b/src/histogramequalizeimage/histogramequalizeimage.cxx
@@ -88,7 +88,7 @@ int main( int argc, char** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/histogramequalizeimage/itkHistogramEqualizationImageFilter.hxx
+++ b/src/histogramequalizeimage/itkHistogramEqualizationImageFilter.hxx
@@ -146,7 +146,7 @@ HistogramEqualizationImageFilter<TImage>
     this->m_LUT[ i ] = static_cast<OutputImagePixelType>(
       std::max(
       static_cast<double>( tempmin ),
-      -1.0 + tempmin + vcl_floor( static_cast<double>( hist[ i ] ) / this->m_MeanFrequency + 0.5 ) ) );
+      -1.0 + tempmin + std::floor( static_cast<double>( hist[ i ] ) / this->m_MeanFrequency + 0.5 ) ) );
   }
 
 } // end BeforeThreadedGenerateData()

--- a/src/histogramequalizeimage/itkHistogramEqualizationImageFilter.hxx
+++ b/src/histogramequalizeimage/itkHistogramEqualizationImageFilter.hxx
@@ -144,7 +144,7 @@ HistogramEqualizationImageFilter<TImage>
   for( unsigned int i = 0; i < this->m_NumberOfBins; i++ )
   {
     this->m_LUT[ i ] = static_cast<OutputImagePixelType>(
-      vnl_math_max(
+      std::max(
       static_cast<double>( tempmin ),
       -1.0 + tempmin + vcl_floor( static_cast<double>( hist[ i ] ) / this->m_MeanFrequency + 0.5 ) ) );
   }

--- a/src/imagestovectorimage/imagestovectorimage.cxx
+++ b/src/imagestovectorimage/imagestovectorimage.cxx
@@ -92,7 +92,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/imagestovectorimage/imagestovectorimage.cxx
+++ b/src/imagestovectorimage/imagestovectorimage.cxx
@@ -93,7 +93,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/imagestovectorimage/imagestovectorimage.cxx
+++ b/src/imagestovectorimage/imagestovectorimage.cxx
@@ -93,7 +93,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/imagestovectorimage/imagestovectorimage.cxx
+++ b/src/imagestovectorimage/imagestovectorimage.cxx
@@ -101,7 +101,7 @@ int main( int argc, char ** argv )
   if( !retgip ) return EXIT_FAILURE;
 
   /** Class that does the work. */
-  ITKToolsImagesToVectorImageBase * filter = NULL;
+  ITKToolsImagesToVectorImageBase * filter = nullptr;
 
   try
   {

--- a/src/imagestovectorimage/imagestovectorimage.cxx
+++ b/src/imagestovectorimage/imagestovectorimage.cxx
@@ -92,7 +92,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/intensityreplace/intensityreplace.cxx
+++ b/src/intensityreplace/intensityreplace.cxx
@@ -107,7 +107,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/intensityreplace/intensityreplace.cxx
+++ b/src/intensityreplace/intensityreplace.cxx
@@ -106,7 +106,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/intensityreplace/intensityreplace.cxx
+++ b/src/intensityreplace/intensityreplace.cxx
@@ -106,7 +106,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/intensityreplace/intensityreplace.cxx
+++ b/src/intensityreplace/intensityreplace.cxx
@@ -119,7 +119,7 @@ int main( int argc, char ** argv )
   if( !retNOCCheck ) return EXIT_FAILURE;
 
   /** Class that does the work. */
-  ITKToolsIntensityReplaceBase * filter = NULL;
+  ITKToolsIntensityReplaceBase * filter = nullptr;
 
   try
   {

--- a/src/intensityreplace/intensityreplace.cxx
+++ b/src/intensityreplace/intensityreplace.cxx
@@ -107,7 +107,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/intensitywindowing/intensitywindowing.cxx
+++ b/src/intensitywindowing/intensitywindowing.cxx
@@ -114,7 +114,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/intensitywindowing/intensitywindowing.cxx
+++ b/src/intensitywindowing/intensitywindowing.cxx
@@ -113,7 +113,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/intensitywindowing/intensitywindowing.cxx
+++ b/src/intensitywindowing/intensitywindowing.cxx
@@ -113,7 +113,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/intensitywindowing/intensitywindowing.cxx
+++ b/src/intensitywindowing/intensitywindowing.cxx
@@ -126,7 +126,7 @@ int main( int argc, char **argv )
   if( !retNOCCheck ) return EXIT_FAILURE;
 
   /** Class that does the work. */
-  ITKToolsIntensityWindowingBase * filter = NULL;
+  ITKToolsIntensityWindowingBase * filter = nullptr;
 
   try
   {

--- a/src/intensitywindowing/intensitywindowing.cxx
+++ b/src/intensitywindowing/intensitywindowing.cxx
@@ -114,7 +114,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/invertintensityimagefilter/invertintensityimagefilter.cxx
+++ b/src/invertintensityimagefilter/invertintensityimagefilter.cxx
@@ -80,7 +80,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/invertintensityimagefilter/invertintensityimagefilter.cxx
+++ b/src/invertintensityimagefilter/invertintensityimagefilter.cxx
@@ -80,7 +80,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/invertintensityimagefilter/invertintensityimagefilter.cxx
+++ b/src/invertintensityimagefilter/invertintensityimagefilter.cxx
@@ -92,7 +92,7 @@ int main( int argc, char ** argv )
   //if( !retNOCCheck ) return EXIT_FAILURE;
 
   /** Class that does the work. */
-  ITKToolsInvertIntensityBase * filter = NULL;
+  ITKToolsInvertIntensityBase * filter = nullptr;
 
   try
   {

--- a/src/invertintensityimagefilter/invertintensityimagefilter.cxx
+++ b/src/invertintensityimagefilter/invertintensityimagefilter.cxx
@@ -79,7 +79,7 @@ int main( int argc, char ** argv )
   parser->GetCommandLineArgument( "-out", outputFileName );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/invertintensityimagefilter/invertintensityimagefilter.cxx
+++ b/src/invertintensityimagefilter/invertintensityimagefilter.cxx
@@ -79,7 +79,7 @@ int main( int argc, char ** argv )
   parser->GetCommandLineArgument( "-out", outputFileName );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/kappastatistic/itkCohenWeightedKappaStatistic.cxx
+++ b/src/kappastatistic/itkCohenWeightedKappaStatistic.cxx
@@ -379,7 +379,7 @@ void CohenWeightedKappaStatistic
     std -= Pe * Pe;
   }
   std /= N * ( 1.0 - Pe ) * ( 1.0 - Pe );
-  std = vcl_sqrt( std );
+  std = std::sqrt( std );
 
 } // end ComputeKappaStatisticValueAndStandardDeviation()
 

--- a/src/kappastatistic/itkCohenWeightedKappaStatistic.cxx
+++ b/src/kappastatistic/itkCohenWeightedKappaStatistic.cxx
@@ -139,7 +139,7 @@ void CohenWeightedKappaStatistic
       }
       else if( weights == "linear" )
       {
-        this->m_Weights[ i ][ j ] = 1.0 - vcl_abs( static_cast<float>( i - j ) ) / ( k - 1.0 );
+        this->m_Weights[ i ][ j ] = 1.0 - std::abs( static_cast<float>( i - j ) ) / ( k - 1.0 );
       }
       else if( weights == "quadratic" )
       {

--- a/src/kappastatistic/itkCohenWeightedKappaStatistic.cxx
+++ b/src/kappastatistic/itkCohenWeightedKappaStatistic.cxx
@@ -143,7 +143,7 @@ void CohenWeightedKappaStatistic
       }
       else if( weights == "quadratic" )
       {
-        this->m_Weights[ i ][ j ] = 1.0 - vnl_math_sqr( ( i - j ) / ( k - 1.0 ) );
+        this->m_Weights[ i ][ j ] = 1.0 - vnl_math::sqr( ( i - j ) / ( k - 1.0 ) );
       }
     }
   }

--- a/src/kappastatistic/itkFleissKappaStatistic.cxx
+++ b/src/kappastatistic/itkFleissKappaStatistic.cxx
@@ -171,7 +171,7 @@ void FleissKappaStatistic
   std = Pe - ( 2.0 * n - 3.0 ) * Pe * Pe + 2.0 * ( n - 2.0 ) * p3;
   std /= ( 1.0 - Pe ) * ( 1.0 - Pe );
   std *= 2.0 / ( N * n * ( n - 1.0 ) );
-  std = vcl_sqrt( std );
+  std = std::sqrt( std );
 
   /** Compute kappa. */
   kappa = ( Po - Pe ) / ( 1.0 - Pe );

--- a/src/logicalimageoperator/itkBinaryLogicalFunctors.h
+++ b/src/logicalimageoperator/itkBinaryLogicalFunctors.h
@@ -195,7 +195,7 @@ struct BinaryLogicalFunctorFactory
     }
     else
     {
-      return NULL;
+      return nullptr;
     }
   }
 };

--- a/src/logicalimageoperator/itkUnaryLogicalFunctors.h
+++ b/src/logicalimageoperator/itkUnaryLogicalFunctors.h
@@ -70,7 +70,7 @@ struct UnaryLogicalFunctorFactory
     }
     else
     {
-      return NULL;
+      return nullptr;
     }
   }
 }; // end struct UnaryLogicalFunctorFactory

--- a/src/logicalimageoperator/logicalimageoperator.cxx
+++ b/src/logicalimageoperator/logicalimageoperator.cxx
@@ -158,7 +158,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/logicalimageoperator/logicalimageoperator.cxx
+++ b/src/logicalimageoperator/logicalimageoperator.cxx
@@ -166,7 +166,7 @@ int main( int argc, char **argv )
   if( !retgip ) return EXIT_FAILURE;
 
   /** Class that does the work. */
-  ITKToolsLogicalImageOperatorBase * filter = NULL;
+  ITKToolsLogicalImageOperatorBase * filter = nullptr;
 
   try
   {

--- a/src/logicalimageoperator/logicalimageoperator.cxx
+++ b/src/logicalimageoperator/logicalimageoperator.cxx
@@ -157,7 +157,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/logicalimageoperator/logicalimageoperator.cxx
+++ b/src/logicalimageoperator/logicalimageoperator.cxx
@@ -157,7 +157,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/logicalimageoperator/logicalimageoperator.cxx
+++ b/src/logicalimageoperator/logicalimageoperator.cxx
@@ -158,7 +158,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/meanstdimage/meanstdimage.cxx
+++ b/src/meanstdimage/meanstdimage.cxx
@@ -101,7 +101,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/meanstdimage/meanstdimage.cxx
+++ b/src/meanstdimage/meanstdimage.cxx
@@ -100,7 +100,7 @@ int main( int argc, char **argv )
   const bool useCompression = parser->ArgumentExists( "-z" );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/meanstdimage/meanstdimage.cxx
+++ b/src/meanstdimage/meanstdimage.cxx
@@ -100,7 +100,7 @@ int main( int argc, char **argv )
   const bool useCompression = parser->ArgumentExists( "-z" );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/meanstdimage/meanstdimage.cxx
+++ b/src/meanstdimage/meanstdimage.cxx
@@ -101,7 +101,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/morphology/gradient.h
+++ b/src/morphology/gradient.h
@@ -49,7 +49,7 @@ void gradient(
 
   /** Setup the gradient filter. BASIC = 0, HISTO = 1, ANCHOR = 2, VHGW = 3. */
   filter->SetKernel( structuringElement );
-  filter->SetAlgorithm( algorithm );
+  filter->SetAlgorithm( static_cast<itk::MathematicalMorphologyEnums::Algorithm>(algorithm) );
   filter->SetInput( reader->GetOutput() );
 
   /** Write the output image. */

--- a/src/morphology/itkParabolicErodeDilateImageFilter.txx
+++ b/src/morphology/itkParabolicErodeDilateImageFilter.txx
@@ -157,8 +157,10 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage >
   // Set up the multithreaded processing
   typename ImageSource< TOutputImage >::ThreadStruct str;
   str.Filter = this;
-  this->GetMultiThreader()->SetNumberOfThreads(this->GetNumberOfWorkUnits());
-  this->GetMultiThreader()->SetSingleMethod(this->ThreaderCallback, &str);
+  auto& multiThreader = *(this->GetMultiThreader());
+  multiThreader.SetMaximumNumberOfThreads(multiThreader.GetNumberOfWorkUnits());
+  multiThreader.SetNumberOfWorkUnits(multiThreader.GetMaximumNumberOfThreads());
+  multiThreader.SetSingleMethod(this->ThreaderCallback, &str);
 
   // multithread the execution
   for( unsigned int d=0; d<ImageDimension; d++ )

--- a/src/morphology/itkParabolicErodeDilateImageFilter.txx
+++ b/src/morphology/itkParabolicErodeDilateImageFilter.txx
@@ -157,7 +157,7 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage >
   // Set up the multithreaded processing
   typename ImageSource< TOutputImage >::ThreadStruct str;
   str.Filter = this;
-  this->GetMultiThreader()->SetNumberOfThreads(this->GetNumberOfThreads());
+  this->GetMultiThreader()->SetNumberOfThreads(this->GetNumberOfWorkUnits());
   this->GetMultiThreader()->SetSingleMethod(this->ThreaderCallback, &str);
 
   // multithread the execution

--- a/src/morphology/itkParabolicOpenCloseImageFilter.txx
+++ b/src/morphology/itkParabolicOpenCloseImageFilter.txx
@@ -180,8 +180,10 @@ ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage >
   // Set up the multithreaded processing
   typename ImageSource< TOutputImage >::ThreadStruct str;
   str.Filter = this;
-  this->GetMultiThreader()->SetNumberOfThreads(this->GetNumberOfWorkUnits());
-  this->GetMultiThreader()->SetSingleMethod(this->ThreaderCallback, &str);
+  auto& multiThreader = *(this->GetMultiThreader());
+  multiThreader.SetMaximumNumberOfThreads(multiThreader.GetNumberOfWorkUnits());
+  multiThreader.SetNumberOfWorkUnits(multiThreader.GetMaximumNumberOfThreads());
+  multiThreader.SetSingleMethod(this->ThreaderCallback, &str);
 
   // multithread the execution - stage 1
   this->m_Stage=1;

--- a/src/morphology/itkParabolicOpenCloseImageFilter.txx
+++ b/src/morphology/itkParabolicOpenCloseImageFilter.txx
@@ -180,7 +180,7 @@ ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage >
   // Set up the multithreaded processing
   typename ImageSource< TOutputImage >::ThreadStruct str;
   str.Filter = this;
-  this->GetMultiThreader()->SetNumberOfThreads(this->GetNumberOfThreads());
+  this->GetMultiThreader()->SetNumberOfThreads(this->GetNumberOfWorkUnits());
   this->GetMultiThreader()->SetSingleMethod(this->ThreaderCallback, &str);
 
   // multithread the execution - stage 1

--- a/src/morphology/itkParabolicOpenCloseSafeBorderImageFilter.txx
+++ b/src/morphology/itkParabolicOpenCloseSafeBorderImageFilter.txx
@@ -31,7 +31,7 @@ ParabolicOpenCloseSafeBorderImageFilter<TInputImage, doOpen, TOutputImage>
     this->m_StatsFilt->Update();
     InputPixelType range = this->m_StatsFilt->GetMaximum() - this->m_StatsFilt->GetMinimum();
     typename MorphFilterType::RadiusType Sigma = this->m_MorphFilt->GetScale();
-    typename TInputImage::SpacingType spcing = this->m_StatsFilt->GetOutput()->GetSpacing();
+    typename TInputImage::SpacingType spcing = this->GetInput()->GetSpacing();
     for (unsigned s = 0; s < ImageDimension;s++)
       {
       if( this->m_MorphFilt->GetUseImageSpacing())
@@ -50,7 +50,7 @@ ParabolicOpenCloseSafeBorderImageFilter<TInputImage, doOpen, TOutputImage>
     this->m_PadFilt->SetPadLowerBound(Bounds);
     this->m_PadFilt->SetPadUpperBound(Bounds);
     this->m_PadFilt->SetConstant(NumericTraits<InputPixelType>::max());
-    this->m_PadFilt->SetInput( this->m_StatsFilt->GetOutput());
+    this->m_PadFilt->SetInput( this->GetInput());
     progress->RegisterInternalFilter( this->m_PadFilt, 0.1f );
     inputImage = this->m_PadFilt->GetOutput();
     }

--- a/src/naryimageoperator/NaryFilterFactory.h
+++ b/src/naryimageoperator/NaryFilterFactory.h
@@ -94,7 +94,7 @@ public:
     else
     {
       std::cerr << "Invalid filter type specified!" << std::endl;
-      return NULL;
+      return nullptr;
     }
   }
 };

--- a/src/naryimageoperator/NaryImageOperatorMainHelper.h
+++ b/src/naryimageoperator/NaryImageOperatorMainHelper.h
@@ -31,8 +31,8 @@
 
 int DetermineImageProperties(
   const std::vector<std::string> & inputFileNames,
-  itk::ImageIOBase::IOComponentType & componentTypeIn,
-  itk::ImageIOBase::IOComponentType & componentTypeOut,
+  itk::ImageIOBase::IOComponentEnum & componentTypeIn,
+  itk::ImageIOBase::IOComponentEnum & componentTypeOut,
   unsigned int & inputDimension )
 {
   /** Determine image properties of image 0. */
@@ -55,7 +55,7 @@ int DetermineImageProperties(
 
   /** Determine image properties of other images. */
   itk::ImageIOBase::IOPixelType inputPixelType_i;
-  itk::ImageIOBase::IOComponentType componentTypeIn_i = componentTypeIn;
+  itk::ImageIOBase::IOComponentEnum componentTypeIn_i = componentTypeIn;
   unsigned int inputDimension_i = 2;
   unsigned int numberOfComponents_i = 1;
   std::vector<unsigned int> imagesize_i;

--- a/src/naryimageoperator/NaryImageOperatorMainHelper.h
+++ b/src/naryimageoperator/NaryImageOperatorMainHelper.h
@@ -36,7 +36,7 @@ int DetermineImageProperties(
   unsigned int & inputDimension )
 {
   /** Determine image properties of image 0. */
-  itk::ImageIOBase::IOPixelType inputPixelType0;
+  itk::IOPixelEnum inputPixelType0;
   unsigned int inputDimension0 = 2;
   unsigned int numberOfComponents0 = 1;
   std::vector<unsigned int> imagesize0( inputDimension0, 0 );
@@ -54,7 +54,7 @@ int DetermineImageProperties(
   if( !retgip0 ) return 1;
 
   /** Determine image properties of other images. */
-  itk::ImageIOBase::IOPixelType inputPixelType_i;
+  itk::IOPixelEnum inputPixelType_i;
   itk::ImageIOBase::IOComponentEnum componentTypeIn_i = componentTypeIn;
   unsigned int inputDimension_i = 2;
   unsigned int numberOfComponents_i = 1;

--- a/src/naryimageoperator/NaryImageOperatorMainHelper.h
+++ b/src/naryimageoperator/NaryImageOperatorMainHelper.h
@@ -108,11 +108,11 @@ int DetermineImageProperties(
   bool outIsInteger = itktools::ComponentTypeIsInteger( componentTypeOut );
   if( outIsInteger )
   {
-    componentTypeIn = itk::ImageIOBase::LONG;
+    componentTypeIn = itk::IOComponentEnum::LONG;
   }
   else
   {
-    componentTypeIn = itk::ImageIOBase::DOUBLE;
+    componentTypeIn = itk::IOComponentEnum::DOUBLE;
   }
 
   /** Return a value indicating success. */

--- a/src/naryimageoperator/itkNaryFunctors.h
+++ b/src/naryimageoperator/itkNaryFunctors.h
@@ -147,7 +147,7 @@ public:
     AccumulateType result = static_cast< AccumulateType >( B[ 0 ] );
     for( unsigned int i = 1; i < B.size(); i++ )
     {
-      result = vnl_math_max( result, B[ i ] );
+      result = std::max( result, B[ i ] );
     }
     return static_cast< TOutput >( result );
   }

--- a/src/naryimageoperator/itkNaryFunctors.h
+++ b/src/naryimageoperator/itkNaryFunctors.h
@@ -169,7 +169,7 @@ public:
     AccumulateType result = static_cast< AccumulateType >( B[ 0 ] );
     for( unsigned int i = 1; i < B.size(); i++ )
     {
-      result = vnl_math_min( result, B[ i ] );
+      result = std::min( result, B[ i ] );
     }
     return static_cast< TOutput >( result );
   }

--- a/src/naryimageoperator/itkNaryFunctors.h
+++ b/src/naryimageoperator/itkNaryFunctors.h
@@ -215,7 +215,7 @@ public:
     {
       result += B[ i ] * B[ i ];
     }
-    return static_cast< TOutput >( vcl_sqrt( result ) );
+    return static_cast< TOutput >( std::sqrt( result ) );
   }
 };
 

--- a/src/naryimageoperator/naryimageoperator.cxx
+++ b/src/naryimageoperator/naryimageoperator.cxx
@@ -124,8 +124,8 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOComponentType componentTypeIn = itk::ImageIOBase::LONG;
-  itk::ImageIOBase::IOComponentType componentTypeOut = itk::ImageIOBase::LONG;
+  itk::ImageIOBase::IOComponentEnum componentTypeIn = itk::ImageIOBase::LONG;
+  itk::ImageIOBase::IOComponentEnum componentTypeOut = itk::ImageIOBase::LONG;
   unsigned int dim = 2;
   int retdip = DetermineImageProperties( inputFileNames,
     componentTypeIn, componentTypeOut, dim );

--- a/src/naryimageoperator/naryimageoperator.cxx
+++ b/src/naryimageoperator/naryimageoperator.cxx
@@ -124,8 +124,8 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOComponentEnum componentTypeIn = itk::ImageIOBase::LONG;
-  itk::ImageIOBase::IOComponentEnum componentTypeOut = itk::ImageIOBase::LONG;
+  itk::ImageIOBase::IOComponentEnum componentTypeIn = itk::IOComponentEnum::LONG;
+  itk::ImageIOBase::IOComponentEnum componentTypeOut = itk::IOComponentEnum::LONG;
   unsigned int dim = 2;
   int retdip = DetermineImageProperties( inputFileNames,
     componentTypeIn, componentTypeOut, dim );
@@ -143,7 +143,7 @@ int main( int argc, char **argv )
 
     if( !itktools::ComponentTypeIsInteger( componentTypeOut ) )
     {
-      componentTypeIn = itk::ImageIOBase::DOUBLE;
+      componentTypeIn = itk::IOComponentEnum::DOUBLE;
     }
   }
 

--- a/src/naryimageoperator/naryimageoperator.cxx
+++ b/src/naryimageoperator/naryimageoperator.cxx
@@ -157,7 +157,7 @@ int main( int argc, char **argv )
   if( !retCOA ) return EXIT_FAILURE;
 
   /** Class that does the work. */
-  ITKToolsNaryImageOperatorBase * filter = NULL;
+  ITKToolsNaryImageOperatorBase * filter = nullptr;
 
   try
   {

--- a/src/pca/itkPCAImageToImageFilter.txx
+++ b/src/pca/itkPCAImageToImageFilter.txx
@@ -291,7 +291,7 @@ namespace itk
       /** In this case the number of required PC's have been
        * specified.
        */
-      unsigned int numberOfValidOutputs = vnl_math_min(
+      unsigned int numberOfValidOutputs = std::min(
         this->m_NumberOfFeatureImages,
         this->m_NumberOfPrincipalComponentsRequired );
       this->SetAndCreateOutputs( numberOfValidOutputs );

--- a/src/pca/pca.cxx
+++ b/src/pca/pca.cxx
@@ -103,7 +103,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/pca/pca.cxx
+++ b/src/pca/pca.cxx
@@ -102,7 +102,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/pca/pca.cxx
+++ b/src/pca/pca.cxx
@@ -103,7 +103,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/pca/pca.cxx
+++ b/src/pca/pca.cxx
@@ -102,7 +102,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/reflect/reflect.cxx
+++ b/src/reflect/reflect.cxx
@@ -119,7 +119,7 @@ int main( int argc, char ** argv )
   }
 
   /** Class that does the work. */
-  ITKToolsReflectBase * filter = NULL;
+  ITKToolsReflectBase * filter = nullptr;
 
   try
   {

--- a/src/reflect/reflect.cxx
+++ b/src/reflect/reflect.cxx
@@ -91,7 +91,7 @@ int main( int argc, char ** argv )
   bool retopct = parser->GetCommandLineArgument( "-opct", componentTypeAsString );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/reflect/reflect.cxx
+++ b/src/reflect/reflect.cxx
@@ -92,7 +92,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/reflect/reflect.cxx
+++ b/src/reflect/reflect.cxx
@@ -92,7 +92,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/reflect/reflect.cxx
+++ b/src/reflect/reflect.cxx
@@ -91,7 +91,7 @@ int main( int argc, char ** argv )
   bool retopct = parser->GetCommandLineArgument( "-opct", componentTypeAsString );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/replacevoxel/replacevoxel.cxx
+++ b/src/replacevoxel/replacevoxel.cxx
@@ -92,7 +92,7 @@ int main( int argc, char ** argv )
   parser->GetCommandLineArgument( "-val", value );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/replacevoxel/replacevoxel.cxx
+++ b/src/replacevoxel/replacevoxel.cxx
@@ -93,7 +93,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/replacevoxel/replacevoxel.cxx
+++ b/src/replacevoxel/replacevoxel.cxx
@@ -93,7 +93,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/replacevoxel/replacevoxel.cxx
+++ b/src/replacevoxel/replacevoxel.cxx
@@ -92,7 +92,7 @@ int main( int argc, char ** argv )
   parser->GetCommandLineArgument( "-val", value );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/rescaleintensityimagefilter/rescaleintensityimagefilter.cxx
+++ b/src/rescaleintensityimagefilter/rescaleintensityimagefilter.cxx
@@ -134,7 +134,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(
@@ -144,7 +144,7 @@ int main( int argc, char **argv )
   /** If the option -mv is used then output is float. */
   if( retmv )
   {
-    componentType = itk::ImageIOBase::FLOAT;
+    componentType = itk::IOComponentEnum::FLOAT;
   }
 
   /** Let the user overrule this. */

--- a/src/rescaleintensityimagefilter/rescaleintensityimagefilter.cxx
+++ b/src/rescaleintensityimagefilter/rescaleintensityimagefilter.cxx
@@ -134,7 +134,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/rescaleintensityimagefilter/rescaleintensityimagefilter.cxx
+++ b/src/rescaleintensityimagefilter/rescaleintensityimagefilter.cxx
@@ -133,7 +133,7 @@ int main( int argc, char **argv )
   if( retmv ) valuesAreExtrema = false;
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/rescaleintensityimagefilter/rescaleintensityimagefilter.cxx
+++ b/src/rescaleintensityimagefilter/rescaleintensityimagefilter.cxx
@@ -133,7 +133,7 @@ int main( int argc, char **argv )
   if( retmv ) valuesAreExtrema = false;
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/rescaleintensityimagefilter/rescaleintensityimagefilter.h
+++ b/src/rescaleintensityimagefilter/rescaleintensityimagefilter.h
@@ -167,8 +167,8 @@ public:
 
         /** Setup the shiftscaler. */
         shiftscaler->SetInput( indexSelectionFilter->GetOutput() );
-        shiftscaler->SetShift( this->m_Values[ 0 ] * sigma / vcl_sqrt( this->m_Values[ 1 ] ) - mean );
-        shiftscaler->SetScale( vcl_sqrt( this->m_Values[ 1 ] ) / sigma );
+        shiftscaler->SetShift( this->m_Values[ 0 ] * sigma / std::sqrt( this->m_Values[ 1 ] ) - mean );
+        shiftscaler->SetScale( std::sqrt( this->m_Values[ 1 ] ) / sigma );
         shiftscaler->Update();
 
         /** Setup the recombining. */

--- a/src/reshape/reshape.cxx
+++ b/src/reshape/reshape.cxx
@@ -89,7 +89,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-s", outputSize );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/reshape/reshape.cxx
+++ b/src/reshape/reshape.cxx
@@ -90,7 +90,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/reshape/reshape.cxx
+++ b/src/reshape/reshape.cxx
@@ -89,7 +89,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-s", outputSize );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/reshape/reshape.cxx
+++ b/src/reshape/reshape.cxx
@@ -90,7 +90,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/resizeimage/resizeimage.cxx
+++ b/src/resizeimage/resizeimage.cxx
@@ -105,7 +105,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/resizeimage/resizeimage.cxx
+++ b/src/resizeimage/resizeimage.cxx
@@ -105,7 +105,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/resizeimage/resizeimage.cxx
+++ b/src/resizeimage/resizeimage.cxx
@@ -104,7 +104,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-io", interpolationOrder );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/resizeimage/resizeimage.cxx
+++ b/src/resizeimage/resizeimage.cxx
@@ -104,7 +104,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-io", interpolationOrder );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
+++ b/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
@@ -158,7 +158,7 @@ CartesianToSphericalCoordinateImageFilter<TInputImage,TOutputImage>
         PointType cornerPoint;
         inputPtr->TransformIndexToPhysicalPoint( cornerIndex, cornerPoint);
         VectorType vec = cornerPoint - cor;
-        maxR = vnl_math_max( maxR, vec.GetNorm() );
+        maxR = std::max( maxR, vec.GetNorm() );
       }
     }
   }
@@ -242,7 +242,7 @@ CartesianToSphericalCoordinateImageFilter<TInputImage,TOutputImage>
   for( unsigned int i = 0; i < ImageDimension; ++i )
   {
     dVrtp = vnl_math_min( this->m_OutputSpacing[ i ], dVrtp);
-    dVxyz = vnl_math_max( this->m_InputSpacing[ i ], dVxyz);
+    dVxyz = std::max( this->m_InputSpacing[ i ], dVxyz);
   }
   double deltaVolumeRatioFactor =
     ( dVrtp / dVxyz ) * ( dVrtp / dVxyz ) * ( dVrtp / dVxyz );

--- a/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
+++ b/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
@@ -290,7 +290,7 @@ CartesianToSphericalCoordinateImageFilter<TInputImage,TOutputImage>
       VectorType vec0 = inPoint - cor;
       /** compute r^2 sin(phi) */
       const double r2 = vec0.GetSquaredNorm() ;
-      const double sinphi = vcl_sin( std::acos( vec0[2] / std::sqrt(r2) ) );
+      const double sinphi = std::sin( std::acos( vec0[2] / std::sqrt(r2) ) );
 
       /** Compute the number of samples needed */
       const double deltaVolumeRatio = deltaVolumeRatioFactor * r2 * sinphi;

--- a/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
+++ b/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
@@ -356,7 +356,7 @@ CartesianToSphericalCoordinateImageFilter<TInputImage,TOutputImage>
         sumImage->TransformPhysicalPointToContinuousIndex( rtpPoint, rtpCIndex);
         for( unsigned int i=0 ; i < ImageDimension; ++i )
         {
-          rtpIndex0[ i ] = static_cast<int>( vcl_floor( rtpCIndex[ i ] ) );
+          rtpIndex0[ i ] = static_cast<int>( std::floor( rtpCIndex[ i ] ) );
           parzenWeight(i,0) = kernel->Evaluate(
             static_cast<double>(rtpIndex0[ i ]) - rtpCIndex[ i ] );
           parzenWeight(i,1) = kernel->Evaluate(

--- a/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
+++ b/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
@@ -290,7 +290,7 @@ CartesianToSphericalCoordinateImageFilter<TInputImage,TOutputImage>
       VectorType vec0 = inPoint - cor;
       /** compute r^2 sin(phi) */
       const double r2 = vec0.GetSquaredNorm() ;
-      const double sinphi = vcl_sin( vcl_acos( vec0[2] / vcl_sqrt(r2) ) );
+      const double sinphi = vcl_sin( vcl_acos( vec0[2] / std::sqrt(r2) ) );
 
       /** Compute the number of samples needed */
       const double deltaVolumeRatio = deltaVolumeRatioFactor * r2 * sinphi;

--- a/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
+++ b/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
@@ -241,7 +241,7 @@ CartesianToSphericalCoordinateImageFilter<TInputImage,TOutputImage>
   double dVxyz = 0.0;
   for( unsigned int i = 0; i < ImageDimension; ++i )
   {
-    dVrtp = vnl_math_min( this->m_OutputSpacing[ i ], dVrtp);
+    dVrtp = std::min( this->m_OutputSpacing[ i ], dVrtp);
     dVxyz = std::max( this->m_InputSpacing[ i ], dVxyz);
   }
   double deltaVolumeRatioFactor =

--- a/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
+++ b/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
@@ -290,7 +290,7 @@ CartesianToSphericalCoordinateImageFilter<TInputImage,TOutputImage>
       VectorType vec0 = inPoint - cor;
       /** compute r^2 sin(phi) */
       const double r2 = vec0.GetSquaredNorm() ;
-      const double sinphi = vcl_sin( vcl_acos( vec0[2] / std::sqrt(r2) ) );
+      const double sinphi = vcl_sin( std::acos( vec0[2] / std::sqrt(r2) ) );
 
       /** Compute the number of samples needed */
       const double deltaVolumeRatio = deltaVolumeRatioFactor * r2 * sinphi;
@@ -341,7 +341,7 @@ CartesianToSphericalCoordinateImageFilter<TInputImage,TOutputImage>
         {
           theta += 2.0* vnl_math::pi;
         }
-        const double phi = vcl_acos( z / r );
+        const double phi = std::acos( z / r );
 
         /** Find out in which voxels in the sumImage and countImage we have to do something */
         PointType rtpPoint;

--- a/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
+++ b/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
@@ -303,7 +303,7 @@ CartesianToSphericalCoordinateImageFilter<TInputImage,TOutputImage>
       {
         /** Use ceil: at least 1 sample! */
         numberOfSamplesPerVoxel = static_cast<unsigned int>(
-          vcl_ceil( 1.0 / deltaVolumeRatio ) );
+          std::ceil( 1.0 / deltaVolumeRatio ) );
       }
 
       /** For the first iteration use the indexPoint. This makes sure that,

--- a/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
+++ b/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
@@ -336,7 +336,7 @@ CartesianToSphericalCoordinateImageFilter<TInputImage,TOutputImage>
 
         /** compute r, theta and phi */
         const double r = vec.GetNorm() ;
-        double theta = vcl_atan2( y, x);
+        double theta = std::atan2( y, x);
         if( theta<0 )
         {
           theta += 2.0* vnl_math::pi;

--- a/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
+++ b/src/segmentationdistance/itkCartesianToSphericalCoordinateImageFilter.txx
@@ -478,7 +478,7 @@ CartesianToSphericalCoordinateImageFilter<TInputImage,TOutputImage>
       if( counts > 1e-14 )
       {
         outIt.Value() = static_cast<OutputPixelType>(
-          vnl_math_rnd( sumIt.Value() / counts ) );
+          vnl_math::rnd( sumIt.Value() / counts ) );
       }
       ++sumIt;
       ++countsIt;

--- a/src/segmentationdistance/segmentationdistance.cxx
+++ b/src/segmentationdistance/segmentationdistance.cxx
@@ -132,7 +132,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/segmentationdistance/segmentationdistance.cxx
+++ b/src/segmentationdistance/segmentationdistance.cxx
@@ -131,7 +131,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/segmentationdistance/segmentationdistance.cxx
+++ b/src/segmentationdistance/segmentationdistance.cxx
@@ -131,7 +131,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/segmentationdistance/segmentationdistance.cxx
+++ b/src/segmentationdistance/segmentationdistance.cxx
@@ -132,7 +132,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(
@@ -147,7 +147,7 @@ int main( int argc, char **argv )
    * than short are supported, but automatically converted to short.
    * The output distance image is always float.
    */
-  componentType = itk::ImageIOBase::FLOAT;
+  componentType = itk::IOComponentEnum::FLOAT;
 
   /** Class that does the work. */
   ITKToolsSegmentationDistanceBase * filter = nullptr;

--- a/src/segmentationdistance/segmentationdistance.cxx
+++ b/src/segmentationdistance/segmentationdistance.cxx
@@ -150,7 +150,7 @@ int main( int argc, char **argv )
   componentType = itk::ImageIOBase::FLOAT;
 
   /** Class that does the work. */
-  ITKToolsSegmentationDistanceBase * filter = NULL;
+  ITKToolsSegmentationDistanceBase * filter = nullptr;
 
   try
   {

--- a/src/segmentationdistance/segmentationdistance.h
+++ b/src/segmentationdistance/segmentationdistance.h
@@ -507,7 +507,7 @@ public:
           inputImage1->TransformIndexToPhysicalPoint(
             cornerIndex, cornerPoint);
           VectorType vec = cornerPoint - cor;
-          maxR = vnl_math_max( maxR, vec.GetNorm() );
+          maxR = std::max( maxR, vec.GetNorm() );
         }
       }
     }

--- a/src/segmentationdistance/segmentationdistance.h
+++ b/src/segmentationdistance/segmentationdistance.h
@@ -21,7 +21,6 @@
 #include "ITKToolsBase.h"
 
 #include "itkImage.h"
-#include "itkExceptionObject.h"
 #include "itkImageFileReader.h"
 #include "itkConstantPadImageFilter.h"
 #include "itkSignedMaurerDistanceMapImageFilter.h"

--- a/src/segmentationdistance/segmentationdistance.h
+++ b/src/segmentationdistance/segmentationdistance.h
@@ -518,7 +518,7 @@ public:
 
     /** Computing spherical transforms */
     RTPSizeType rtpSize;
-    rtpSize[0] = static_cast<unsigned int>( vcl_ceil(maxR / minSpacing ) );
+    rtpSize[0] = static_cast<unsigned int>( std::ceil(maxR / minSpacing ) );
     std::cout << "r = " << rtpSize[0] << std::endl;
     rtpSize[1] = thetasize;
     rtpSize[2] = phisize;

--- a/src/segmentationdistance/segmentationdistance.h
+++ b/src/segmentationdistance/segmentationdistance.h
@@ -436,7 +436,7 @@ public:
     SpacingType inputSpacing = inputImage1->GetSpacing();
     for( unsigned int i = 0; i < Dimension; ++i )
     {
-      minSpacing = vnl_math_min( minSpacing, inputSpacing[ i ]);
+      minSpacing = std::min( minSpacing, inputSpacing[ i ]);
     }
 
     /** Find distanceMap2==0 pixels */

--- a/src/segmentationdistance/segmentationdistance.h
+++ b/src/segmentationdistance/segmentationdistance.h
@@ -198,10 +198,10 @@ public:
     padder2->Update();
 
     /** Compute the distance */
-    typename ImageType::Pointer accum1 = 0;
-    typename ImageType::Pointer accum2 = 0;
-    typename ImageType::Pointer dist = 0;
-    typename ImageType::Pointer edge = 0;
+    typename ImageType::Pointer accum1 = nullptr;
+    typename ImageType::Pointer accum2 = nullptr;
+    typename ImageType::Pointer dist = nullptr;
+    typename ImageType::Pointer edge = nullptr;
 
     std::vector<double> cor = this->m_Mancor;
 
@@ -241,10 +241,10 @@ public:
     }
 
     /** Compute again the distance */
-    typename ImageType::Pointer accum1inv = 0;
-    typename ImageType::Pointer accum2inv = 0;
-    typename ImageType::Pointer distinv = 0;
-    typename ImageType::Pointer edgeinv = 0;
+    typename ImageType::Pointer accum1inv = nullptr;
+    typename ImageType::Pointer accum2inv = nullptr;
+    typename ImageType::Pointer distinv = nullptr;
+    typename ImageType::Pointer edgeinv = nullptr;
 
     SegmentationDistanceHelper<InputImageType1, InputImageType2, ImageType>(
       invInputImage1, invInputImage2, accum1inv, accum2inv, distinv, edgeinv,

--- a/src/splitsegmentation/splitsegmentation.cxx
+++ b/src/splitsegmentation/splitsegmentation.cxx
@@ -112,7 +112,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/splitsegmentation/splitsegmentation.cxx
+++ b/src/splitsegmentation/splitsegmentation.cxx
@@ -111,7 +111,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/splitsegmentation/splitsegmentation.cxx
+++ b/src/splitsegmentation/splitsegmentation.cxx
@@ -111,7 +111,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/splitsegmentation/splitsegmentation.cxx
+++ b/src/splitsegmentation/splitsegmentation.cxx
@@ -112,7 +112,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/statisticsonimage/itkStatisticsImageFilterWithMask.txx
+++ b/src/statisticsonimage/itkStatisticsImageFilterWithMask.txx
@@ -341,7 +341,7 @@ StatisticsImageFilter<TInputImage>
     / (static_cast<RealType>(count) - 1);
   // in case of numerical errors the variance might be <0.
   variance = vnl_math_max(0.0, variance);
-  sigma = vcl_sqrt(variance);
+  sigma = std::sqrt(variance);
 
   // Set the outputs
   this->GetMinimumOutput()->Set( minimum );

--- a/src/statisticsonimage/itkStatisticsImageFilterWithMask.txx
+++ b/src/statisticsonimage/itkStatisticsImageFilterWithMask.txx
@@ -390,7 +390,7 @@ StatisticsImageFilter<TInputImage>
       }
 
       sum += realValue;
-      absoluteSum += vnl_math_abs(realValue);
+      absoluteSum += std::abs(realValue);
       sumOfSquares += (realValue * realValue);
       ++count;
       ++it;
@@ -422,7 +422,7 @@ StatisticsImageFilter<TInputImage>
         }
 
         sum += realValue;
-        absoluteSum += vnl_math_abs(realValue);
+        absoluteSum += std::abs(realValue);
         sumOfSquares += (realValue * realValue);
         ++count;
       }

--- a/src/statisticsonimage/itkStatisticsImageFilterWithMask.txx
+++ b/src/statisticsonimage/itkStatisticsImageFilterWithMask.txx
@@ -340,7 +340,7 @@ StatisticsImageFilter<TInputImage>
   variance = (sumOfSquares - (sum*sum / static_cast<RealType>(count)))
     / (static_cast<RealType>(count) - 1);
   // in case of numerical errors the variance might be <0.
-  variance = vnl_math_max(0.0, variance);
+  variance = std::max(0.0, variance);
   sigma = std::sqrt(variance);
 
   // Set the outputs

--- a/src/statisticsonimage/itkStatisticsImageFilterWithMask.txx
+++ b/src/statisticsonimage/itkStatisticsImageFilterWithMask.txx
@@ -269,7 +269,7 @@ void
 StatisticsImageFilter<TInputImage>
 ::BeforeThreadedGenerateData( void )
 {
-  int numberOfThreads = this->GetNumberOfThreads();
+  int numberOfThreads = this->GetNumberOfWorkUnits();
 
   // Resize the thread temporaries
   this->m_Count.SetSize(numberOfThreads);
@@ -298,7 +298,7 @@ StatisticsImageFilter<TInputImage>
   long count;
   RealType sumOfSquares;
 
-  int numberOfThreads = this->GetNumberOfThreads();
+  int numberOfThreads = this->GetNumberOfWorkUnits();
 
   PixelType minimum;
   PixelType maximum;

--- a/src/statisticsonimage/statisticsonimage.cxx
+++ b/src/statisticsonimage/statisticsonimage.cxx
@@ -113,7 +113,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/statisticsonimage/statisticsonimage.cxx
+++ b/src/statisticsonimage/statisticsonimage.cxx
@@ -130,7 +130,7 @@ int main( int argc, char ** argv )
   componentType = itk::ImageIOBase::FLOAT;
 
   /** Class that does the work. */
-  ITKToolsStatisticsOnImageBase * filter = NULL;
+  ITKToolsStatisticsOnImageBase * filter = nullptr;
 
   try
   {

--- a/src/statisticsonimage/statisticsonimage.cxx
+++ b/src/statisticsonimage/statisticsonimage.cxx
@@ -113,7 +113,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(
@@ -127,7 +127,7 @@ int main( int argc, char ** argv )
   std::cout << "\tNumberOfComponents: " << numberOfComponents << std::endl;
 
   /** Force images to sneaky be converted to float. */
-  componentType = itk::ImageIOBase::FLOAT;
+  componentType = itk::IOComponentEnum::FLOAT;
 
   /** Class that does the work. */
   ITKToolsStatisticsOnImageBase * filter = nullptr;

--- a/src/statisticsonimage/statisticsonimage.cxx
+++ b/src/statisticsonimage/statisticsonimage.cxx
@@ -112,7 +112,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/statisticsonimage/statisticsonimage.cxx
+++ b/src/statisticsonimage/statisticsonimage.cxx
@@ -112,7 +112,7 @@ int main( int argc, char ** argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/statisticsonimage/statisticsonimage.h
+++ b/src/statisticsonimage/statisticsonimage.h
@@ -72,7 +72,7 @@ public:
   ITKToolsStatisticsOnImage(){};
   ~ITKToolsStatisticsOnImage(){};
 
-  static Self * New( unsigned int dim, unsigned int numberOfComponents, itk::ImageIOBase::IOComponentType componentType )
+  static Self * New( unsigned int dim, unsigned int numberOfComponents, itk::ImageIOBase::IOComponentEnum componentType )
   {
     if( itktools::IsType<TComponentType>( componentType )
       && VDimension == dim && VNumberOfComponents == numberOfComponents )

--- a/src/statisticsonimage/statisticsonimage.hxx
+++ b/src/statisticsonimage/statisticsonimage.hxx
@@ -290,10 +290,10 @@ ITKToolsStatisticsOnImage< VDimension, VNumberOfComponents, TComponentType >
 
     double binsize = static_cast<double>( maxPixelValue - minPixelValue )
       / static_cast<double>( numberOfBins );
-    binsize = vnl_math_max( binsize, epsilon );
-    double uppermargin = vnl_math_max( epsilon, binsize / marginalScale );
+    binsize = std::max( binsize, epsilon );
+    double uppermargin = std::max( epsilon, binsize / marginalScale );
     histogramMax = static_cast<RealPixelType>(
-      vnl_math_max( binsize * static_cast<double>( numberOfBins ) + minPixelValue,
+      std::max( binsize * static_cast<double>( numberOfBins ) + minPixelValue,
       maxPixelValue + uppermargin ) );
   }
   /** Integer pixeltypes. in principle this function will never be called

--- a/src/statisticsonimage/statisticsprinters.h
+++ b/src/statisticsonimage/statisticsprinters.h
@@ -55,8 +55,8 @@ void PrintGeometricStatistics( const TStatisticsFilter * statistics )
 {
   /** Print to screen. */
   std::cout << std::setprecision(10);
-  double geometricmean = vcl_exp( statistics->GetMean() );
-  double geometricstdev = vcl_exp( statistics->GetSigma() );
+  double geometricmean = std::exp( statistics->GetMean() );
+  double geometricstdev = std::exp( statistics->GetSigma() );
   std::cout << "\tgeometric mean : " << geometricmean << std::endl;
   std::cout << "\tgeometric stdev: " << geometricstdev << std::endl;
 

--- a/src/texture/itkGrayLevelCooccurrenceMatrixTextureCoefficientsCalculator.txx
+++ b/src/texture/itkGrayLevelCooccurrenceMatrixTextureCoefficientsCalculator.txx
@@ -105,7 +105,7 @@ GrayLevelCooccurrenceMatrixTextureCoefficientsCalculator< THistogram >
   std::vector<double> marginalSums( binsPerAxis, 0.0 );
 
   /** Walk over the histogram. Only once instead of 4! */
-  double log2 = vcl_log(2.);
+  double log2 = std::log(2.);
   HistogramConstIterator hit( this->m_Histogram );
   for ( hit = this->m_Histogram->Begin(); hit != this->m_Histogram->End(); ++hit )
   {
@@ -140,7 +140,7 @@ GrayLevelCooccurrenceMatrixTextureCoefficientsCalculator< THistogram >
 
     /** Compute the features that can be computed in this loop immediately. */
     this->m_Energy += frequency * frequency;
-    this->m_Entropy -= ( frequency > 0.0001 ) ? frequency * vcl_log( frequency ) / log2 : 0.0;
+    this->m_Entropy -= ( frequency > 0.0001 ) ? frequency * std::log( frequency ) / log2 : 0.0;
     this->m_InverseDifferenceMoment += frequency /
       ( 1.0 + ( index[ 0 ] - index[ 1 ] ) * ( index[ 0 ] - index[ 1 ] ) );
     this->m_Inertia += ( index[ 0 ] - index[ 1 ] ) * ( index[ 0 ] - index[ 1 ] ) * frequency;

--- a/src/texture/itkScalarImageToGrayLevelCooccurrenceMatrixGenerator.txx
+++ b/src/texture/itkScalarImageToGrayLevelCooccurrenceMatrixGenerator.txx
@@ -97,7 +97,7 @@ ScalarImageToGrayLevelCooccurrenceMatrixGenerator<
   {
     for( unsigned int i = 0; i < offsets.Value().GetOffsetDimension(); i++ )
     {
-      unsigned int distance = vnl_math_abs( offsets.Value()[ i ] );
+      unsigned int distance = std::abs( offsets.Value()[ i ] );
       if( distance > minRadius )
       {
         minRadius = distance;

--- a/src/texture/texture.cxx
+++ b/src/texture/texture.cxx
@@ -119,7 +119,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(
@@ -137,7 +137,7 @@ int main( int argc, char **argv )
    * but can be overridden by specifying -opct in the command line.
    */
   componentType = itk::ImageIOBase::FLOAT;
-  itk::ImageIOBase::IOComponentType outputComponentType
+  itk::ImageIOBase::IOComponentEnum outputComponentType
     = itk::ImageIOBase::GetComponentTypeFromString( componentTypeOutString );
 
   try

--- a/src/texture/texture.cxx
+++ b/src/texture/texture.cxx
@@ -118,7 +118,7 @@ int main( int argc, char **argv )
     maximumNumberOfThreads );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/texture/texture.cxx
+++ b/src/texture/texture.cxx
@@ -118,7 +118,7 @@ int main( int argc, char **argv )
     maximumNumberOfThreads );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/texture/texture.cxx
+++ b/src/texture/texture.cxx
@@ -131,7 +131,7 @@ int main( int argc, char **argv )
   if( !retNOCCheck ) return EXIT_FAILURE;
 
   /** Class that does the work. */
-  ITKToolsTextureBase * filter = NULL;
+  ITKToolsTextureBase * filter = nullptr;
 
   /** Input images are read in as float, always. The default output is float,
    * but can be overridden by specifying -opct in the command line.

--- a/src/texture/texture.cxx
+++ b/src/texture/texture.cxx
@@ -113,8 +113,8 @@ int main( int argc, char **argv )
 
   /** Threads. */
   unsigned int maximumNumberOfThreads
-    = itk::MultiThreader::GetGlobalDefaultNumberOfThreads();
-  itk::MultiThreader::SetGlobalMaximumNumberOfThreads(
+    = itk::MultiThreaderBase::GetGlobalDefaultNumberOfThreads();
+  itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads(
     maximumNumberOfThreads );
 
   /** Determine image properties. */

--- a/src/texture/texture.cxx
+++ b/src/texture/texture.cxx
@@ -119,7 +119,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(
@@ -136,7 +136,7 @@ int main( int argc, char **argv )
   /** Input images are read in as float, always. The default output is float,
    * but can be overridden by specifying -opct in the command line.
    */
-  componentType = itk::ImageIOBase::FLOAT;
+  componentType = itk::IOComponentEnum::FLOAT;
   itk::ImageIOBase::IOComponentEnum outputComponentType
     = itk::ImageIOBase::GetComponentTypeFromString( componentTypeOutString );
 

--- a/src/texture/texture.h
+++ b/src/texture/texture.h
@@ -25,7 +25,7 @@
 #include "itkTextureImageToImageFilter.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
-#include "itkMultiThreader.h"
+#include "itkMultiThreaderBase.h"
 
 
 /** \class ITKToolsTextureBase

--- a/src/thresholdimage/itkAdaptiveOtsuThresholdImageFilter.txx
+++ b/src/thresholdimage/itkAdaptiveOtsuThresholdImageFilter.txx
@@ -59,7 +59,7 @@ AdaptiveOtsuThresholdImageFilter()
   this->m_OutsideValue = 0;
   this->m_InsideValue = 1;
 
-  this->m_PointSet = NULL;
+  this->m_PointSet = nullptr;
 
   this->Superclass::SetNumberOfRequiredInputs( 1 );
   this->Superclass::SetNumberOfRequiredOutputs( 1 );

--- a/src/thresholdimage/itkMinErrorThresholdImageCalculator.txx
+++ b/src/thresholdimage/itkMinErrorThresholdImageCalculator.txx
@@ -34,7 +34,7 @@ template<class TInputImage>
 MinErrorThresholdImageCalculator<TInputImage>
 ::MinErrorThresholdImageCalculator()
 {
-  this->m_Image = NULL;
+  this->m_Image = nullptr;
   this->m_Threshold = NumericTraits<PixelType>::Zero;
   this->m_NumberOfHistogramBins = 128;
   this->m_RegionSetByUser = false;

--- a/src/thresholdimage/itkMinErrorThresholdImageCalculator.txx
+++ b/src/thresholdimage/itkMinErrorThresholdImageCalculator.txx
@@ -184,7 +184,7 @@ MinErrorThresholdImageCalculator<TInputImage>
       varLeft+=(vnl_math_sqr(i-meanLeft)*relativeFrequency[ i ]);
       }
     varLeft/=priorLeft;
-    stdLeft = vcl_sqrt(varLeft); //standard deviation
+    stdLeft = std::sqrt(varLeft); //standard deviation
 
     //compute the current parameters for right (foreground) mixture component
     priorRight = 0.0; //Prior Probability
@@ -201,7 +201,7 @@ MinErrorThresholdImageCalculator<TInputImage>
       varRight+=(vnl_math_sqr(i-meanRight)*relativeFrequency[ i ]);
       }
     varRight/=priorRight;
-    stdRight = vcl_sqrt(varRight); //standard deviation
+    stdRight = std::sqrt(varRight); //standard deviation
     //Make sure you don't end up with zero values for the parameters
     priorLeft += std::numeric_limits<long double>::epsilon();
     priorRight += std::numeric_limits<long double>::epsilon();
@@ -260,7 +260,7 @@ MinErrorThresholdImageCalculator<TInputImage>
       varLeft+=(vnl_math_sqr(j-m_AlphaLeft)*relativeFrequency[j]);
       }
     varLeft/=m_PriorLeft;
-    this->m_StdLeft=vcl_sqrt(varLeft);
+    this->m_StdLeft=std::sqrt(varLeft);
 
     varRight = 0.0;
     for ( j=i+1; j<m_NumberOfHistogramBins; j++)
@@ -268,7 +268,7 @@ MinErrorThresholdImageCalculator<TInputImage>
       varRight+=(vnl_math_sqr(j-m_AlphaRight)*relativeFrequency[j]);
       }
     varRight/=m_PriorRight;
-    this->m_StdRight=vcl_sqrt(varRight);
+    this->m_StdRight=std::sqrt(varRight);
     }
   this->m_AlphaLeft= imageMin + ( this->m_AlphaLeft+1) / binMultiplier ;
   this->m_AlphaRight= imageMin + ( this->m_AlphaRight+1) / binMultiplier ;

--- a/src/thresholdimage/itkMinErrorThresholdImageCalculator.txx
+++ b/src/thresholdimage/itkMinErrorThresholdImageCalculator.txx
@@ -209,8 +209,8 @@ MinErrorThresholdImageCalculator<TInputImage>
     stdRight += std::numeric_limits<long double>::epsilon();
 
     //compute the values of the error functions at the current threshold (j)
-    errorFunctionPois[j] = totalMean-priorLeft*(vcl_log(priorLeft)+meanLeft*vcl_log(meanLeft))-priorRight*(vcl_log(priorRight)+meanRight*vcl_log(meanRight));
-    errorFunctionGaus[j] = 1+2*(priorLeft*vcl_log(stdLeft)+priorRight*vcl_log(stdRight))-2*(priorLeft*vcl_log(priorLeft)+priorRight*vcl_log(priorRight));
+    errorFunctionPois[j] = totalMean-priorLeft*(std::log(priorLeft)+meanLeft*std::log(meanLeft))-priorRight*(std::log(priorRight)+meanRight*std::log(meanRight));
+    errorFunctionGaus[j] = 1+2*(priorLeft*std::log(stdLeft)+priorRight*std::log(stdRight))-2*(priorLeft*std::log(priorLeft)+priorRight*std::log(priorRight));
     }
 
   //find the threshold value that minimizes each of the error functions

--- a/src/thresholdimage/itkMinErrorThresholdImageCalculator.txx
+++ b/src/thresholdimage/itkMinErrorThresholdImageCalculator.txx
@@ -135,7 +135,7 @@ MinErrorThresholdImageCalculator<TInputImage>
       }
     else
       {
-      binNumber = (unsigned int) vcl_ceil((value - imageMin) * binMultiplier ) - 1;
+      binNumber = (unsigned int) std::ceil((value - imageMin) * binMultiplier ) - 1;
       if( binNumber == this->m_NumberOfHistogramBins ) // in case of rounding errors
         {
         binNumber -= 1;

--- a/src/thresholdimage/itkMinErrorThresholdImageCalculator.txx
+++ b/src/thresholdimage/itkMinErrorThresholdImageCalculator.txx
@@ -181,7 +181,7 @@ MinErrorThresholdImageCalculator<TInputImage>
     meanLeft/=priorLeft;
     for ( i=0; i<=j; i++ )
       {
-      varLeft+=(vnl_math_sqr(i-meanLeft)*relativeFrequency[ i ]);
+      varLeft+=(vnl_math::sqr(i-meanLeft)*relativeFrequency[ i ]);
       }
     varLeft/=priorLeft;
     stdLeft = std::sqrt(varLeft); //standard deviation
@@ -198,7 +198,7 @@ MinErrorThresholdImageCalculator<TInputImage>
     meanRight/=priorRight;
     for ( i=j+1; i<m_NumberOfHistogramBins; i++ )
       {
-      varRight+=(vnl_math_sqr(i-meanRight)*relativeFrequency[ i ]);
+      varRight+=(vnl_math::sqr(i-meanRight)*relativeFrequency[ i ]);
       }
     varRight/=priorRight;
     stdRight = std::sqrt(varRight); //standard deviation
@@ -257,7 +257,7 @@ MinErrorThresholdImageCalculator<TInputImage>
     varLeft = 0.0;
     for (j=0; j<=i; j++)
       {
-      varLeft+=(vnl_math_sqr(j-m_AlphaLeft)*relativeFrequency[j]);
+      varLeft+=(vnl_math::sqr(j-m_AlphaLeft)*relativeFrequency[j]);
       }
     varLeft/=m_PriorLeft;
     this->m_StdLeft=std::sqrt(varLeft);
@@ -265,7 +265,7 @@ MinErrorThresholdImageCalculator<TInputImage>
     varRight = 0.0;
     for ( j=i+1; j<m_NumberOfHistogramBins; j++)
       {
-      varRight+=(vnl_math_sqr(j-m_AlphaRight)*relativeFrequency[j]);
+      varRight+=(vnl_math::sqr(j-m_AlphaRight)*relativeFrequency[j]);
       }
     varRight/=m_PriorRight;
     this->m_StdRight=std::sqrt(varRight);

--- a/src/thresholdimage/itkOtsuThresholdWithMaskImageCalculator.txx
+++ b/src/thresholdimage/itkOtsuThresholdWithMaskImageCalculator.txx
@@ -34,8 +34,8 @@ template<class TInputImage>
 OtsuThresholdWithMaskImageCalculator<TInputImage>
 ::OtsuThresholdWithMaskImageCalculator()
 {
-  this->m_Image = NULL;
-  this->m_MaskImage = NULL;
+  this->m_Image = nullptr;
+  this->m_MaskImage = nullptr;
   this->m_Threshold = NumericTraits<PixelType>::Zero;
   this->m_NumberOfHistogramBins = 128;
   this->m_RegionSetByUser = false;

--- a/src/thresholdimage/itkOtsuThresholdWithMaskImageCalculator.txx
+++ b/src/thresholdimage/itkOtsuThresholdWithMaskImageCalculator.txx
@@ -129,7 +129,7 @@ OtsuThresholdWithMaskImageCalculator<TInputImage>
       }
     else
       {
-      binNumber = (unsigned int) vcl_ceil((value - imageMin) * binMultiplier ) - 1;
+      binNumber = (unsigned int) std::ceil((value - imageMin) * binMultiplier ) - 1;
       if( binNumber == this->m_NumberOfHistogramBins ) // in case of rounding errors
         {
         binNumber -= 1;

--- a/src/thresholdimage/itkOtsuThresholdWithMaskImageCalculator.txx
+++ b/src/thresholdimage/itkOtsuThresholdWithMaskImageCalculator.txx
@@ -159,7 +159,7 @@ OtsuThresholdWithMaskImageCalculator<TInputImage>
   double meanRight = ( totalMean - freqLeft ) / ( 1.0 - freqLeft );
 
   double maxVarBetween = freqLeft * ( 1.0 - freqLeft ) *
-    vnl_math_sqr( meanLeft - meanRight );
+    vnl_math::sqr( meanLeft - meanRight );
   int maxBinNumber = 0;
 
   double freqLeftOld = freqLeft;
@@ -180,7 +180,7 @@ OtsuThresholdWithMaskImageCalculator<TInputImage>
         ( 1.0 - freqLeft );
       }
     double varBetween = freqLeft * ( 1.0 - freqLeft ) *
-      vnl_math_sqr( meanLeft - meanRight );
+      vnl_math::sqr( meanLeft - meanRight );
 
     if( varBetween > maxVarBetween )
       {

--- a/src/thresholdimage/thresholdimage.cxx
+++ b/src/thresholdimage/thresholdimage.cxx
@@ -181,7 +181,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/thresholdimage/thresholdimage.cxx
+++ b/src/thresholdimage/thresholdimage.cxx
@@ -182,7 +182,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/thresholdimage/thresholdimage.cxx
+++ b/src/thresholdimage/thresholdimage.cxx
@@ -181,7 +181,7 @@ int main( int argc, char **argv )
   }
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/thresholdimage/thresholdimage.cxx
+++ b/src/thresholdimage/thresholdimage.cxx
@@ -182,7 +182,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/thresholdimage/thresholdimage.hxx
+++ b/src/thresholdimage/thresholdimage.hxx
@@ -66,7 +66,7 @@ ITKToolsThresholdImage< VDimension, TComponentType >
   reader->SetFileName( inputFileName.c_str() );
 
   /** Apply the threshold. */
-  lowerthreshold = static_cast<InputPixelType>( vnl_math_max(
+  lowerthreshold = static_cast<InputPixelType>( std::max(
     static_cast<double>( itk::NumericTraits<InputPixelType>::NonpositiveMin() ),
     threshold1 ) );
   thresholder->SetLowerThreshold( lowerthreshold );

--- a/src/tileimages/tileimages.cxx
+++ b/src/tileimages/tileimages.cxx
@@ -121,7 +121,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/tileimages/tileimages.cxx
+++ b/src/tileimages/tileimages.cxx
@@ -144,7 +144,7 @@ int main( int argc, char ** argv )
   if( !retly )
   {
     /** Class that does the work. */
-    ITKToolsTileImages2D3DBase * filterTile2D3D = NULL;
+    ITKToolsTileImages2D3DBase * filterTile2D3D = nullptr;
 
     try
     {
@@ -187,7 +187,7 @@ int main( int argc, char ** argv )
   else
   {
     /** Class that does the work. */
-    ITKToolsTileImagesBase * filter = NULL;
+    ITKToolsTileImagesBase * filter = nullptr;
 
     try
     {

--- a/src/tileimages/tileimages.cxx
+++ b/src/tileimages/tileimages.cxx
@@ -120,7 +120,7 @@ int main( int argc, char ** argv )
   parser->GetCommandLineArgument( "-d", defaultvalue );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/tileimages/tileimages.cxx
+++ b/src/tileimages/tileimages.cxx
@@ -120,7 +120,7 @@ int main( int argc, char ** argv )
   parser->GetCommandLineArgument( "-d", defaultvalue );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/tileimages/tileimages.cxx
+++ b/src/tileimages/tileimages.cxx
@@ -121,7 +121,7 @@ int main( int argc, char ** argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/ttest/ttest.cxx
+++ b/src/ttest/ttest.cxx
@@ -239,9 +239,9 @@ bool ReadInputData( const std::string & filename, std::vector<std::vector<double
      *   char separator = '/', bool isPath = false );
      * The columns are assumed to be separated by one space ' ' or one tab '\t'.
      */
-    std::vector<itksys::String> linevec1 = itksys::SystemTools::SplitString(
+    std::vector<std::string> linevec1 = itksys::SystemTools::SplitString(
       line.c_str(), ' ', false );
-    std::vector<itksys::String> linevec2 = itksys::SystemTools::SplitString(
+    std::vector<std::string> linevec2 = itksys::SystemTools::SplitString(
       line.c_str(), '\t', false );
     unsigned int linelength = linevec1.size() > linevec2.size() ? linevec1.size() : linevec2.size();
 

--- a/src/ttest/ttest.cxx
+++ b/src/ttest/ttest.cxx
@@ -312,7 +312,7 @@ bool ComputeTValue( const std::vector<double> & samples1,
       std1, std2, stddiff );
 
     /** Compute the t-value. */
-    tValue = meandiff * vcl_sqrt( static_cast<double>( samples1.size() ) ) / stddiff;
+    tValue = meandiff * std::sqrt( static_cast<double>( samples1.size() ) ) / stddiff;
   }
   else
   {
@@ -349,7 +349,7 @@ void ComputeMeanAndStandardDeviation(
     std += ( vec[ i ] - mean ) * ( vec[ i ] - mean );
   }
   std /= ( vec.size() - 1 );
-  std = vcl_sqrt( std );
+  std = std::sqrt( std );
   */
 
   /** Compute mean and std fast, using one loop. */
@@ -367,10 +367,10 @@ void ComputeMeanAndStandardDeviation(
     ssd += ( samples1[ i ] - samples2[ i ] ) * ( samples1[ i ] - samples2[ i ] );
   }
   mean1 = s1 / N;
-  std1 = vcl_sqrt( ( ss1 * N - s1 * s1 ) / ( N * ( N - 1.0 ) ) );
+  std1 = std::sqrt( ( ss1 * N - s1 * s1 ) / ( N * ( N - 1.0 ) ) );
   mean2 = s2 / N;
-  std2 = vcl_sqrt( ( ss2 * N - s2 * s2 ) / ( N * ( N - 1.0 ) ) );
+  std2 = std::sqrt( ( ss2 * N - s2 * s2 ) / ( N * ( N - 1.0 ) ) );
   meandiff = sd / N;
-  stddiff = vcl_sqrt( ( ssd * N - sd * sd ) / ( N * ( N - 1.0 ) ) );
+  stddiff = std::sqrt( ( ssd * N - sd * sd ) / ( N * ( N - 1.0 ) ) );
 
 } // end ComputeMeanAndStandardDeviation()

--- a/src/ttest/ttest.cxx
+++ b/src/ttest/ttest.cxx
@@ -184,7 +184,7 @@ int main( int argc, char **argv )
   DistributionType::Pointer distributionFunction = DistributionType::New();
   distributionFunction->SetDegreesOfFreedom( samples1.size() - 1 );
   //double pValue = distributionFunction->EvaluateCDF( tValue );
-  double pValue = distributionFunction->EvaluateCDF( -vcl_abs( tValue ) );
+  double pValue = distributionFunction->EvaluateCDF( -std::abs( tValue ) );
 
   /** For a 2-tailed t-test, multiply with 2. */
   if( tail == 2 ) pValue *= 2.0;

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -545,7 +545,7 @@ public:
   ~ARCTAN() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_atan( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::atan( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -497,7 +497,7 @@ public:
   ~TAN() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_tan( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::tan( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -226,7 +226,7 @@ public:
   ~RPOWER() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_pow( static_cast<double>( A ), static_cast<double>( this->m_Argument ) ) );
+    return static_cast<TOutput>( std::pow( static_cast<double>( A ), static_cast<double>( this->m_Argument ) ) );
   }
   void SetArgument( TArgument arg ){ this->m_Argument = arg; };
 private:
@@ -241,7 +241,7 @@ public:
   ~LPOWER() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_pow( static_cast<double>( this->m_Argument ), static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::pow( static_cast<double>( this->m_Argument ), static_cast<double>( A ) ) );
   }
   void SetArgument( TArgument arg ){ this->m_Argument = arg; };
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -513,7 +513,7 @@ public:
   ~ARCSIN() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_asin( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::asin( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -449,7 +449,7 @@ public:
   ~EXP() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_exp( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::exp( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -385,7 +385,7 @@ public:
   ~SQR() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vnl_math_sqr( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( vnl_math::sqr( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -273,7 +273,7 @@ public:
   ~SIGNINT() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vnl_math_sgn( A ) );
+    return static_cast<TOutput>( vnl_math::sgn( A ) );
   }
 
 private:
@@ -289,7 +289,7 @@ public:
   ~SIGNDOUBLE() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vnl_math_sgn( A ) );
+    return static_cast<TOutput>( vnl_math::sgn( A ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -353,7 +353,7 @@ public:
   ~CEIL() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_ceil( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::ceil( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -147,7 +147,7 @@ public:
   ~RMODDOUBLE() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_fmod( static_cast<double>( A ), static_cast<double>( this->m_Argument ) ) );
+    return static_cast<TOutput>( std::fmod( static_cast<double>( A ), static_cast<double>( this->m_Argument ) ) );
   }
   void SetArgument( TArgument arg ){ this->m_Argument = arg; };
 private:
@@ -177,7 +177,7 @@ public:
   ~LMODDOUBLE() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_fmod( static_cast<double>( this->m_Argument ), static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::fmod( static_cast<double>( this->m_Argument ), static_cast<double>( A ) ) );
   }
   void SetArgument( TArgument arg ){ this->m_Argument = arg; };
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -465,7 +465,7 @@ public:
   ~SIN() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_sin( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::sin( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -305,7 +305,7 @@ public:
   ~ABSINT() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_abs( static_cast<int>( A ) ) );
+    return static_cast<TOutput>( std::abs( static_cast<int>( A ) ) );
   }
 
 private:
@@ -321,7 +321,7 @@ public:
   ~ABSDOUBLE() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_abs( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::abs( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -920,7 +920,7 @@ struct UnaryFunctorFactory
     else
     {
       std::cerr << "Selected functor is not valid!" << std::endl;
-      return NULL;
+      return nullptr;
     }
   }
 };

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -401,7 +401,7 @@ public:
   ~SQRT() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_sqrt( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::sqrt( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -369,7 +369,7 @@ public:
   ~ROUND() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vnl_math_rnd( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( vnl_math::rnd( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -481,7 +481,7 @@ public:
   ~COS() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_cos( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::cos( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -337,7 +337,7 @@ public:
   ~FLOOR() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_floor( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::floor( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -192,7 +192,7 @@ public:
   ~NLOG() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_log( static_cast<double>( A ) ) / vcl_log( static_cast<double>( this->m_Argument ) ) );
+    return static_cast<TOutput>( std::log( static_cast<double>( A ) ) / std::log( static_cast<double>( this->m_Argument ) ) );
   }
   void SetArgument( TArgument arg ){ this->m_Argument = arg; };
 private:
@@ -417,7 +417,7 @@ public:
   ~LN() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_log( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::log( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -433,7 +433,7 @@ public:
   ~LOG10() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_log10( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::log10( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/itkUnaryFunctors.h
+++ b/src/unaryimageoperator/itkUnaryFunctors.h
@@ -529,7 +529,7 @@ public:
   ~ARCCOS() {};
   inline TOutput operator()( const TInput & A )
   {
-    return static_cast<TOutput>( vcl_acos( static_cast<double>( A ) ) );
+    return static_cast<TOutput>( std::acos( static_cast<double>( A ) ) );
   }
 
 private:

--- a/src/unaryimageoperator/unaryimageoperator.cxx
+++ b/src/unaryimageoperator/unaryimageoperator.cxx
@@ -171,7 +171,7 @@ int main( int argc, char **argv )
   }
 
   /** Class that does the work. */
-  ITKToolsUnaryImageOperatorBase * filter = NULL;
+  ITKToolsUnaryImageOperatorBase * filter = nullptr;
 
   unsigned int dim = 0;
   itktools::GetImageDimension( inputFileName, dim );

--- a/src/unaryimageoperator/unaryimageoperator.cxx
+++ b/src/unaryimageoperator/unaryimageoperator.cxx
@@ -128,11 +128,11 @@ int main( int argc, char **argv )
   bool inputIsInteger = itktools::ComponentTypeIsInteger( inputComponentType );
   if( inputIsInteger )
   {
-    inputComponentType = itk::ImageIOBase::INT;
+    inputComponentType = itk::IOComponentEnum::INT;
   }
   else
   {
-    inputComponentType = itk::ImageIOBase::DOUBLE;
+    inputComponentType = itk::IOComponentEnum::DOUBLE;
   }
 
   /** Get the correct form of ops. For some operators

--- a/src/unaryimageoperator/unaryimageoperator.cxx
+++ b/src/unaryimageoperator/unaryimageoperator.cxx
@@ -113,10 +113,10 @@ int main( int argc, char **argv )
   }
 
   /** Get the input and output component type. */
-  itk::ImageIOBase::IOComponentType inputComponentType;
+  itk::ImageIOBase::IOComponentEnum inputComponentType;
   itktools::GetImageComponentType( inputFileName, inputComponentType );
 
-  itk::ImageIOBase::IOComponentType outputComponentType = inputComponentType;
+  itk::ImageIOBase::IOComponentEnum outputComponentType = inputComponentType;
   std::string componentTypeOutString = "";
   bool retopct = parser->GetCommandLineArgument( "-opct", componentTypeOutString );
   if( retopct )
@@ -177,8 +177,8 @@ int main( int argc, char **argv )
   itktools::GetImageDimension( inputFileName, dim );
 
   /** Short aliases. */
-  itk::ImageIOBase::IOComponentType inputType = inputComponentType;
-  itk::ImageIOBase::IOComponentType outputType = outputComponentType;
+  itk::ImageIOBase::IOComponentEnum inputType = inputComponentType;
+  itk::ImageIOBase::IOComponentEnum outputType = outputComponentType;
 
   try
   {

--- a/src/weightedaddition/weightedaddition.cxx
+++ b/src/weightedaddition/weightedaddition.cxx
@@ -101,7 +101,7 @@ int main( int argc, char **argv )
   componentType = itk::ImageIOBase::FLOAT;
 
   /** Class that does the work. */
-  ITKToolsWeightedAdditionBase * filter = NULL;
+  ITKToolsWeightedAdditionBase * filter = nullptr;
 
   try
   {

--- a/src/weightedaddition/weightedaddition.cxx
+++ b/src/weightedaddition/weightedaddition.cxx
@@ -85,7 +85,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-out", outputFileName );
 
   /** Determine image properties. */
-  itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;

--- a/src/weightedaddition/weightedaddition.cxx
+++ b/src/weightedaddition/weightedaddition.cxx
@@ -86,7 +86,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::ImageIOBase::IOPixelType pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentType componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(

--- a/src/weightedaddition/weightedaddition.cxx
+++ b/src/weightedaddition/weightedaddition.cxx
@@ -86,7 +86,7 @@ int main( int argc, char **argv )
 
   /** Determine image properties. */
   itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
-  itk::ImageIOBase::IOComponentEnum componentType = itk::ImageIOBase::UNKNOWNCOMPONENTTYPE;
+  itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;
   bool retgip = itktools::GetImageProperties(
@@ -98,7 +98,7 @@ int main( int argc, char **argv )
   if( !retNOCCheck ) return EXIT_FAILURE;
 
   /** Anyway, float is only supported. */
-  componentType = itk::ImageIOBase::FLOAT;
+  componentType = itk::IOComponentEnum::FLOAT;
 
   /** Class that does the work. */
   ITKToolsWeightedAdditionBase * filter = nullptr;

--- a/src/weightedaddition/weightedaddition.cxx
+++ b/src/weightedaddition/weightedaddition.cxx
@@ -85,7 +85,7 @@ int main( int argc, char **argv )
   parser->GetCommandLineArgument( "-out", outputFileName );
 
   /** Determine image properties. */
-  itk::IOPixelEnum pixelType = itk::ImageIOBase::UNKNOWNPIXELTYPE;
+  itk::IOPixelEnum pixelType = itk::IOPixelEnum::UNKNOWNPIXELTYPE;
   itk::ImageIOBase::IOComponentEnum componentType = itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE;
   unsigned int dim = 0;
   unsigned int numberOfComponents = 0;


### PR DESCRIPTION
@stefanklein 

Made compilable on Visual Studio 2019 and 2022, using ITK v5.3.0 or v5.4rc02.

Note: When buiding ITK, `Module_ITKReview=ON` is required for pxthresholdimage, in order to use `RobustAutomaticThresholdImageFilter`.